### PR TITLE
Fix: Compression when writing files to the created ZIP file

### DIFF
--- a/docx/opc/phys_pkg.py
+++ b/docx/opc/phys_pkg.py
@@ -153,4 +153,4 @@ class _ZipPkgWriter(PhysPkgWriter):
         *pack_uri*.
         """
         zinfo = ZipInfo(filename=pack_uri.membername, date_time=(1980, 1, 1, 0, 0, 0))
-        self._zipf.writestr(zinfo, blob)
+        self._zipf.writestr(zinfo, blob, ZIP_DEFLATED)


### PR DESCRIPTION
Fix regression from #17, original PR from [python-docx#810](https://github.com/python-openxml/python-docx/pull/810).

### Fix
I have fixed the call to `writestr()` to include the compression method `ZIP_DEFLATED` to re-enable compressed files in the created ZIP file. The compression was lost by merging #17.


### Reasoning

In the original `python-docx`, the writing of files is done by
```python
self._zipf.writestr(pack_uri.membername, blob)
```
with the `_zipf` created in `__init__()`
```python
self._zipf = ZipFile(pkg_file, 'w', compression=ZIP_DEFLATED)
```
This ensured that the zip files would be compressed by the Deflate compression method because the `writestr()` method either takes `ZipInfo` or `str`. If you pass `ZipInfo`, it uses that instance.
If you pass `str`, it creates a new `ZipInfo` class with the compression type taken from the `ZipFile` (in this case `ZIP_DEFLATED`).

\
The PR #17 changed writing of files to zip to this:
```python
zinfo = ZipInfo(filename=pack_uri.membername, date_time=(1980, 1, 1, 0, 0, 0))
self._zipf.writestr(zinfo, blob)
```
This means that the files being written into the created ZIP file are not compressed as the `zinfo` object nor the call to `writestr()` doesn't state any compression methods.
