### PR TITLE
docs: make the README link block a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ by [scanny](https://github.com/scanny): everything upstream does, plus features 
 has not adopted. As of 2.0.0 this project tracks upstream v1.2.0 directly, so it builds on
 upstream's typed and tested core rather than a 2021 snapshot of it.
 
-Documentation: <https://toxicphreak.github.io/python-docx-ng/>
-Repo: <https://github.com/toxicphreAK/python-docx-ng>
-Releases: <https://github.com/toxicphreAK/python-docx-ng/releases>
-PyPI: <https://pypi.org/project/python-docx-ng/>
+- Documentation: <https://toxicphreak.github.io/python-docx-ng/>
+- Repo: <https://github.com/toxicphreAK/python-docx-ng>
+- Releases: <https://github.com/toxicphreAK/python-docx-ng/releases>
+- PyPI: <https://pypi.org/project/python-docx-ng/>
 
 ## Installation
 


### PR DESCRIPTION
The Documentation / Repo / Releases / PyPI lines had no hard line breaks, so Markdown ran them together into a single paragraph on GitHub and PyPI alike. Pre-existing; the Documentation line just made it more noticeable.

Using a list rather than trailing double-spaces, since that whitespace is invisible and gets stripped by editors and formatters.

`twine check` still passes on both artifacts.