### PR TITLE
build: modernise the distribution metadata

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,8 @@ Restarted from upstream python-docx v1.2.0. The 0.9.x line had diverged from ups
 v0.8.11 in 2021; rather than merge four years of upstream change into that tree, this
 release branches from upstream and re-applies the python-docx-ng features on top.
 
-**This is a breaking release.** See ``docs/user/migrating-from-0-9.rst`` for a migration
+**This is a breaking release.** See
+https://toxicphreak.github.io/python-docx-ng/user/migrating-from-0-9/ for a migration
 path.
 
 Breaking changes
@@ -98,6 +99,18 @@ Fixed
 - Tables with no ``w:tblGrid`` are readable, and cell access is linear rather than
   quadratic
 - ``w:highlight w:val="none"`` and fractional half-point font sizes are accepted
+
+Packaging
+~~~~~~~~~
+
+- The license is declared as an SPDX expression (PEP 639) rather than the deprecated
+  table form, and ``LICENSE`` is declared through ``license-files``
+- ``Typing :: Typed`` is declared; the package has shipped ``py.typed`` since 1.2.0
+- The ``lxml`` floor is ``4.5.2``, the oldest release with wheels for a supported Python
+- The unpacked ``default-docx-template/`` is no longer installed. It is the editable
+  source of ``default.docx``, is read by nothing at run time, and stays in the sdist
+- The ``requirements*.txt`` files are removed. ``[dependency-groups]`` in
+  ``pyproject.toml`` is the single list of development dependencies, and ``tox`` reads it
 
 
 1.2.0 (2025-06-16)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,8 @@
-include HISTORY.rst LICENSE README.rst tox.ini
-include requirements*.txt
+include HISTORY.rst LICENSE tox.ini
 graft src/docx/templates
 graft features
 graft tests
 graft docs
-prune docs/.build
 global-exclude .DS_Store
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
+# -- 77.0.0 is where `project.license` accepts an SPDX expression and
+# -- `project.license-files` exists (PEP 639) --
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,12 +10,11 @@ authors = [{name = "toxicphreAK", email = "pentesting.laboratories@gmail.com"}]
 maintainers = [{name = "toxicphreAK", email = "pentesting.laboratories@gmail.com"}]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -21,15 +22,20 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Office/Business :: Office Suites",
     "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 dependencies = [
-    "lxml>=3.1.0",
+    # -- 4.5.2 is the oldest release with wheels for any Python this package
+    # -- supports; anything earlier would have to be built from source --
+    "lxml>=4.5.2",
     "typing_extensions>=4.9.0",
 ]
-description = "python-docx-ng is a Python library for creating and updating Microsoft Word (.docx) files."
+description = "Create, read and update Microsoft Word (.docx) files."
 dynamic = ["version"]
 keywords = ["docx", "office", "openxml", "word"]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.9"
 
@@ -129,4 +135,14 @@ known-local-folder = ["helpers"]
 
 [tool.setuptools.dynamic]
 version = {attr = "docx.__version__"}
+
+# -- `templates/default-docx-template/` is the unpacked form of `default.docx`,
+# -- kept in the repository and the sdist so the template can be edited and
+# -- repacked. No code reads it, so it is not installed. --
+[tool.setuptools.packages.find]
+where = ["src"]
+exclude = ["docx.templates.default-docx-template*"]
+
+[tool.setuptools.exclude-package-data]
+"docx.templates" = ["default-docx-template/*"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
--r requirements-test.txt
-build
-ruff
-setuptools>=61.0.0
-tox
-twine
-types-lxml

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,0 @@
-Sphinx==1.8.6
-Jinja2==2.11.3
-MarkupSafe==0.23
-alabaster<0.7.14
--e .

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,0 @@
--r requirements.txt
-behave>=1.2.3
-pyparsing>=2.0.1
-pytest>=2.5
-pytest-coverage
-pytest-xdist
-ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-lxml>=3.1.0
-typing-extensions

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 envlist = py39, py310, py311, py312, py313
 
 [testenv]
-deps = -rrequirements-test.txt
+# -- the dev group in pyproject.toml is the single list of test dependencies --
+dependency_groups = dev
 
 commands =
-    py.test -qx
+    pytest -qx
     behave --format progress --stop --tags=-wip

--- a/uv.lock
+++ b/uv.lock
@@ -1351,7 +1351,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "lxml", specifier = ">=3.1.0" },
+    { name = "lxml", specifier = ">=4.5.2" },
     { name = "typing-extensions", specifier = ">=4.9.0" },
 ]
 


### PR DESCRIPTION
Follow-up to the docs work: an audit of the packaging metadata, and the fixes for what it turned up.

## On a clock

`uv build` printed two deprecations on every run:

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
SetuptoolsDeprecationWarning: License classifiers are deprecated
  By 2027-Feb-18 ... your builds will no longer be supported.
```

Both are gone. `license = "MIT"` plus `license-files = ["LICENSE"]` (PEP 639), the `License ::` classifier dropped, `setuptools>=77.0.0` in `build-system`. The metadata now carries `License-Expression: MIT`; the wheel was already `Metadata-Version: 2.4`, so that part is unchanged.

## Stale files that shipped to users

`MANIFEST.in` was still the 0.9.x one:

- `include README.rst` — the file is gone, and every build warned about it
- `prune docs/.build` — Sphinx-era path; the build output is `site/` now
- `include requirements*.txt` — put four orphaned files in the sdist

Those four were unreferenced except by `tox.ini`, and **`requirements-docs.txt` still pinned `Sphinx==1.8.6` / `Jinja2==2.11.3` / `MarkupSafe==0.23`** — the set that could not import when the MkDocs migration started. Anyone opening the sdist to find out how to build the docs got a dead toolchain. Removed; `tox` now reads `dependency_groups = dev`, so `[dependency-groups]` is the only list.

## Smaller wheel

`src/docx/templates/default-docx-template/` is the unpacked form of `default.docx`. Nothing in the codebase reads it. It is excluded from the wheel and kept in the repository and the sdist as the editable source.

Wheel: 383,725 → 343,534 bytes.

## Classifiers and dependencies

- `Typing :: Typed` — `py.typed` ships and is in the wheel; the classifier is what makes that discoverable
- `Programming Language :: Python :: 3 :: Only`, `Topic :: Software Development :: Libraries :: Python Modules`
- dropped `Environment :: Console` — inherited from upstream, but there are no entry points
- summary is now `Create, read and update Microsoft Word (.docx) files.` — it no longer opens by repeating the package name, and it mentions reading
- `lxml>=3.1.0` → `lxml>=4.5.2`, the oldest release with wheels for any Python this package supports. 3.1.0 is from 2013 and would have to build from source

`HISTORY.rst` also pointed at `docs/user/migrating-from-0-9.rst`, renamed by the MkDocs migration. It points at the published guide now — it matters because that file is the `Changelog` URL in the metadata.

## Verification

- `uv build` — no deprecation or missing-file warnings
- `twine check` — passes on both artifacts
- `uv run pytest -q` — 2373 passed
- wheel installed in a clean Python 3.9 venv: creates, saves and re-reads a document, styles resolve, `default.docx` present
- `uv run tox config -e py312` — resolves `dependency_groups = dev`
- `uv run ruff check .` — clean

## Not changed

The sdist is 6 MB, 4.2 MB of it `features/` test imagery. Shipping tests is a defensible choice, so it is left alone.

One thing no change here can fix: pypi.org still renders **0.9.7's** README, because `2.0.0.dev0` is a pre-release and PyPI shows the latest stable. None of this is visible there until 2.0.0 is tagged.