### PR TITLE
feat: accept path-like document paths

### DIFF
--- a/src/docx/api.py
+++ b/src/docx/api.py
@@ -27,9 +27,9 @@ _WORD_MAIN_CONTENT_TYPES = (
 )
 
 
-def Document(docx: str | IO[bytes] | None = None) -> DocumentObject:
+def Document(docx: str | os.PathLike[str] | IO[bytes] | None = None) -> DocumentObject:
     """Return a |Document| object loaded from `docx`, where `docx` can be either a path
-    to a ``.docx`` file (a string) or a file-like object.
+    to a ``.docx`` file (a string or ``os.PathLike``) or a file-like object.
 
     Macro-enabled ``.docm`` files and Word templates — ``.dotx`` and ``.dotm`` — are
     also accepted. Their macro storage is preserved when the document is saved, but this
@@ -43,6 +43,8 @@ def Document(docx: str | IO[bytes] | None = None) -> DocumentObject:
     loaded.
     """
     docx = _default_docx_path() if docx is None else docx
+    if isinstance(docx, os.PathLike):
+        docx = os.fspath(docx)
     document_part = cast("DocumentPart", Package.open(docx).main_document_part)
     if document_part.content_type not in _WORD_MAIN_CONTENT_TYPES:
         tmpl = "file '%s' is not a Word file, content type is '%s'"

--- a/src/docx/document.py
+++ b/src/docx/document.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import IO, TYPE_CHECKING, Iterator, List, Sequence
 
 from docx.altchunk import AltChunk
@@ -449,11 +450,15 @@ class Document(ElementProxy):
             CT.WML_TEMPLATE_MACRO_ENABLED_MAIN,
         )
 
-    def save(self, path_or_stream: str | IO[bytes], as_template: bool | None = None):
+    def save(
+        self,
+        path_or_stream: str | os.PathLike[str] | IO[bytes],
+        as_template: bool | None = None,
+    ):
         """Save this document to `path_or_stream`.
 
-        `path_or_stream` can be either a path to a filesystem location (a string) or a
-        file-like object.
+        `path_or_stream` can be either a path to a filesystem location (a string or
+        ``os.PathLike``) or a file-like object.
 
         `as_template` selects whether the result is a Word template (``.dotx`` /
         ``.dotm``) or an ordinary document (``.docx`` / ``.docm``). The default of
@@ -468,6 +473,8 @@ class Document(ElementProxy):
             self._part.content_type = _document_content_type(
                 self._part.content_type, as_template=as_template
             )
+        if isinstance(path_or_stream, os.PathLike):
+            path_or_stream = os.fspath(path_or_stream)
         self._part.save(path_or_stream)
 
     @property

--- a/src/docx/opc/package.py
+++ b/src/docx/opc/package.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import IO, TYPE_CHECKING, Iterator, cast
 
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
@@ -137,8 +138,10 @@ class OpcPackage:
                 return PackURI(candidate_partname)
 
     @classmethod
-    def open(cls, pkg_file: str | IO[bytes]) -> Self:
+    def open(cls, pkg_file: str | os.PathLike[str] | IO[bytes]) -> Self:
         """Return an |OpcPackage| instance loaded with the contents of `pkg_file`."""
+        if isinstance(pkg_file, os.PathLike):
+            pkg_file = os.fspath(pkg_file)
         pkg_reader = PackageReader.from_file(pkg_file)
         package = cls()
         Unmarshaller.unmarshal(pkg_reader, package, PartFactory)
@@ -172,11 +175,13 @@ class OpcPackage:
         relationships for this package."""
         return Relationships(PACKAGE_URI.baseURI)
 
-    def save(self, pkg_file: str | IO[bytes]):
+    def save(self, pkg_file: str | os.PathLike[str] | IO[bytes]):
         """Save this package to `pkg_file`.
 
         `pkg_file` can be either a file-path or a file-like object.
         """
+        if isinstance(pkg_file, os.PathLike):
+            pkg_file = os.fspath(pkg_file)
         for part in self.parts:
             part.before_marshal()
         PackageWriter.write(pkg_file, self.rels, self.parts)

--- a/src/docx/opc/phys_pkg.py
+++ b/src/docx/opc/phys_pkg.py
@@ -1,6 +1,9 @@
 """Provides a general interface to a `physical` OPC package, such as a zip file."""
 
+from __future__ import annotations
+
 import os
+from typing import IO
 from zipfile import ZIP_DEFLATED, BadZipFile, ZipFile, ZipInfo, is_zipfile
 
 from docx.opc.exceptions import EncryptedPackageError, PackageNotFoundError
@@ -43,7 +46,11 @@ def _not_a_package_error(pkg_file):
     An encrypted document gets its own error class; telling the caller their file is
     password-protected is a great deal more useful than "not a zip file".
     """
-    name = pkg_file if isinstance(pkg_file, str) else getattr(pkg_file, "name", pkg_file)
+    name = (
+        os.fspath(pkg_file)
+        if isinstance(pkg_file, (str, os.PathLike))
+        else getattr(pkg_file, "name", pkg_file)
+    )
     if _starts_with_ole_signature(pkg_file):
         return EncryptedPackageError(
             "Package '%s' is an encrypted (password-protected) Office document and"
@@ -57,9 +64,10 @@ def _not_a_package_error(pkg_file):
 class PhysPkgReader:
     """Factory for physical package reader objects."""
 
-    def __new__(cls, pkg_file):
-        # if `pkg_file` is a string, treat it as a path
-        if isinstance(pkg_file, str):
+    def __new__(cls, pkg_file: str | os.PathLike[str] | IO[bytes]):
+        # if `pkg_file` is a string or path-like object, treat it as a path
+        if isinstance(pkg_file, (str, os.PathLike)):
+            pkg_file = os.fspath(pkg_file)
             if os.path.isdir(pkg_file):
                 reader_cls = _DirPkgReader
             elif is_zipfile(pkg_file):
@@ -77,7 +85,9 @@ class PhysPkgReader:
 class PhysPkgWriter:
     """Factory for physical package writer objects."""
 
-    def __new__(cls, pkg_file):
+    def __new__(cls, pkg_file: str | os.PathLike[str] | IO[bytes]):
+        if isinstance(pkg_file, os.PathLike):
+            pkg_file = os.fspath(pkg_file)
         return super(PhysPkgWriter, cls).__new__(_ZipPkgWriter)
 
 

--- a/src/docx/parts/document.py
+++ b/src/docx/parts/document.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import IO, TYPE_CHECKING, cast
 
 from docx.document import Document
@@ -160,9 +161,11 @@ class DocumentPart(StoryPart):
             self.relate_to(numbering_part, RT.NUMBERING)
             return numbering_part
 
-    def save(self, path_or_stream: str | IO[bytes]):
+    def save(self, path_or_stream: str | os.PathLike[str] | IO[bytes]):
         """Save this document to `path_or_stream`, which can be either a path to a
-        filesystem location (a string) or a file-like object."""
+        filesystem location (a string or ``os.PathLike``) or a file-like object."""
+        if isinstance(path_or_stream, os.PathLike):
+            path_or_stream = os.fspath(path_or_stream)
         self.package.save(path_or_stream)
 
     @property

--- a/tests/opc/test_phys_pkg.py
+++ b/tests/opc/test_phys_pkg.py
@@ -71,6 +71,14 @@ class DescribePhysPkgReader:
         with pytest.raises(PackageNotFoundError):
             PhysPkgReader("foobar")
 
+    def it_uses_zip_reader_when_pkg_is_a_pathlib_path(self):
+        phys_reader = PhysPkgReader(pathlib.Path(zip_pkg_path))
+        assert isinstance(phys_reader, _ZipPkgReader)
+
+    def it_uses_dir_reader_when_pkg_is_a_pathlib_path(self):
+        phys_reader = PhysPkgReader(pathlib.Path(dir_pkg_path))
+        assert isinstance(phys_reader, _DirPkgReader)
+
     @pytest.mark.parametrize(
         "blob",
         [
@@ -118,6 +126,13 @@ class DescribePhysPkgReader:
             PhysPkgReader(str(path))
         with pytest.raises(PackageNotFoundError, match="not found at"):
             PhysPkgReader(str(tmp_path / "absent.docx"))
+
+    def it_formats_a_pathlib_path_in_package_errors(self, tmp_path: pathlib.Path):
+        path = tmp_path / "corrupt.docx"
+        path.write_bytes(b"not a zip file at all")
+
+        with pytest.raises(PackageNotFoundError, match=str(path)):
+            PhysPkgReader(path)
 
 
 class DescribeZipPkgReader:

--- a/tests/parts/test_document.py
+++ b/tests/parts/test_document.py
@@ -129,6 +129,17 @@ class DescribeDocumentPart:
 
         package_.save.assert_called_once_with("foobar.docx")
 
+    def it_can_save_the_package_to_a_pathlib_path(self, package_: Mock):
+        from pathlib import Path
+
+        document_part = DocumentPart(
+            PackURI("/word/document.xml"), CT.WML_DOCUMENT, element("w:document"), package_
+        )
+
+        document_part.save(Path("foobar.docx"))
+
+        package_.save.assert_called_once_with("foobar.docx")
+
     def it_provides_access_to_the_comments_added_to_the_document(
         self, _comments_part_prop_: Mock, comments_part_: Mock, comments_: Mock, package_: Mock
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,18 @@ class DescribeDocument:
         Package_.open.assert_called_once_with("default-document.docx")
         assert document is document_
 
+    def it_opens_a_docx_file_from_a_pathlib_path(self, Package_: Mock, document_: Mock):
+        from pathlib import Path
+
+        document_part = Package_.open.return_value.main_document_part
+        document_part.document = document_
+        document_part.content_type = CT.WML_DOCUMENT_MAIN
+
+        document = DocumentFactoryFn(Path("foobar.docx"))
+
+        Package_.open.assert_called_once_with("foobar.docx")
+        assert document is document_
+
     def it_opens_a_macro_enabled_docm_file(self, Package_: Mock, document_: Mock):
         document_part = Package_.open.return_value.main_document_part
         document_part.document = document_

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -240,6 +240,15 @@ class DescribeDocument:
 
         document_part_.save.assert_called_once_with("foobar.docx")
 
+    def it_can_save_the_document_to_a_pathlib_path(self, document_part_: Mock):
+        from pathlib import Path
+
+        document = Document(cast(CT_Document, element("w:document")), document_part_)
+
+        document.save(Path("foobar.docx"))
+
+        document_part_.save.assert_called_once_with("foobar.docx")
+
     def it_provides_access_to_the_comments(self, document_part_: Mock, comments_: Mock):
         document_part_.comments = comments_
         document = Document(cast(CT_Document, element("w:document")), document_part_)


### PR DESCRIPTION
Fixes #111

Accept `os.PathLike` values throughout document open/save APIs, normalize them at package boundaries, and cover archive routing and error formatting with regression tests.