### PR TITLE
fix: support quotes in style lookups

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -93,6 +93,8 @@ Added
 Fixed
 ~~~~~
 
+- Style and latent-style lookup now accepts names and style IDs containing quotes and
+  other XPath metacharacters.
 - Documents with oversized attribute values, which the default ``lxml`` parser rejects,
   now parse. Entity resolution stays off.
 - Corrupt packages and dangling relationships no longer raise on load

--- a/src/docx/oxml/styles.py
+++ b/src/docx/oxml/styles.py
@@ -54,7 +54,7 @@ class CT_LatentStyles(BaseOxmlElement):
 
     def get_by_name(self, name):
         """Return the `w:lsdException` child having `name`, or |None| if not found."""
-        found = self.xpath('w:lsdException[@w:name="%s"]' % name)
+        found = self.xpath("w:lsdException[@w:name=$name]", name=name)
         if not found:
             return None
         return found[0]
@@ -362,16 +362,14 @@ class CT_Styles(BaseOxmlElement):
 
         |None| if not found.
         """
-        xpath = f'w:style[@w:styleId="{styleId}"]'
-        return next(iter(self.xpath(xpath)), None)
+        return next(iter(self.xpath("w:style[@w:styleId=$style_id]", style_id=styleId)), None)
 
     def get_by_name(self, name: str) -> CT_Style | None:
         """`w:style` child with `w:name` grandchild having value `name`.
 
         |None| if not found.
         """
-        xpath = 'w:style[w:name/@w:val="%s"]' % name
-        return next(iter(self.xpath(xpath)), None)
+        return next(iter(self.xpath("w:style[w:name/@w:val=$name]", name=name)), None)
 
     def _iter_styles(self):
         """Generate each of the `w:style` child elements in document order."""

--- a/src/docx/oxml/xmlchemy.py
+++ b/src/docx/oxml/xmlchemy.py
@@ -691,7 +691,10 @@ class BaseOxmlElement(etree.ElementBase, metaclass=MetaOxmlElement):
         return serialize_for_reading(self)
 
     def xpath(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self, xpath_str: str, namespaces: Dict[str, str] | None = None
+        self,
+        xpath_str: str,
+        namespaces: Dict[str, str] | None = None,
+        **variables: Any,
     ) -> Any:
         """Override of `lxml` _Element.xpath() method.
 
@@ -700,10 +703,12 @@ class BaseOxmlElement(etree.ElementBase, metaclass=MetaOxmlElement):
         `namespaces` adds prefixes not in the standard mapping, which is needed to
         query elements from vendor or custom namespaces. Entries override the standard
         mapping where the prefixes collide.
+
+        `variables` binds values to XPath variables, avoiding unsafe string
+        interpolation for user-supplied values.
         """
-        if namespaces is None:
-            return super().xpath(xpath_str, namespaces=nsmap)
-        return super().xpath(xpath_str, namespaces={**nsmap, **namespaces})
+        namespace_map = nsmap if namespaces is None else {**nsmap, **namespaces}
+        return super().xpath(xpath_str, namespaces=namespace_map, **variables)
 
     @property
     def _nsptag(self) -> str:

--- a/tests/oxml/test_styles.py
+++ b/tests/oxml/test_styles.py
@@ -7,12 +7,30 @@ from docx.enum.style import WD_STYLE_TYPE
 from ..unitutil.cxml import element, xml
 
 
+class DescribeCT_LatentStyles:
+    def it_can_find_a_name_containing_xpath_metacharacters(self):
+        name = 'He said "it\'s fine" [today]'
+        latent_styles = element("w:latentStyles")
+        exception = latent_styles.add_lsdException()
+        exception.name = name
+
+        assert latent_styles.get_by_name(name) is exception
+
+
 class DescribeCT_Styles:
     def it_can_add_a_style_of_type(self, add_fixture):
         styles, name, style_type, builtin, expected_xml = add_fixture
         style = styles.add_style_of_type(name, style_type, builtin)
         assert styles.xml == expected_xml
         assert style is styles[-1]
+
+    def it_can_find_a_name_and_id_containing_xpath_metacharacters(self):
+        name = 'He said "it\'s fine" [today]'
+        styles = element("w:styles")
+        style = styles.add_style_of_type(name, WD_STYLE_TYPE.PARAGRAPH, builtin=False)
+
+        assert styles.get_by_name(name) is style
+        assert styles.get_by_id(style.styleId) is style
 
     # fixtures -------------------------------------------------------
 

--- a/tests/oxml/test_xmlchemy.py
+++ b/tests/oxml/test_xmlchemy.py
@@ -68,6 +68,22 @@ class DescribeBaseOxmlElement:
         # -- "w" normally resolves to the wordprocessingml namespace --
         assert len(element.xpath("w:r", namespaces={"w": other_ns})) == 1
 
+    def it_binds_xpath_variables_while_preserving_additional_namespaces(self):
+        vendor_ns = "http://example.com/vendor/2024"
+        value = 'He said "it\'s fine" [today]'
+        element = parse_xml(
+            '<w:p %s xmlns:acme="%s"><acme:custom value="He said &quot;it\'s fine&quot; '
+            '[today]"/></w:p>' % (nsdecls("w"), vendor_ns)
+        )
+
+        matches = element.xpath(
+            "acme:custom[@value=$value]",
+            namespaces={"acme": vendor_ns},
+            value=value,
+        )
+
+        assert len(matches) == 1
+
     # fixtures ---------------------------------------------
 
     @pytest.fixture(

--- a/tests/styles/test_styles.py
+++ b/tests/styles/test_styles.py
@@ -41,6 +41,14 @@ class DescribeStyles:
         style = styles[key]
         assert style._element is expected_element
 
+    def it_can_create_and_get_a_style_with_xpath_metacharacters_in_its_name(self):
+        name = 'He said "it\'s fine" [today]'
+        styles = Styles(element("w:styles"))
+
+        added_style = styles.add_style(name, WD_STYLE_TYPE.PARAGRAPH)
+
+        assert styles[name]._element is added_style._element
+
     def it_raises_on_style_not_found(self, get_raises_fixture):
         styles, key = get_raises_fixture
         with pytest.raises(KeyError):


### PR DESCRIPTION
## Summary

- bind user-supplied style names and IDs as XPath variables instead of interpolating them into expressions
- forward XPath variables through `BaseOxmlElement.xpath()` while preserving standard and custom namespace merging
- cover style, style-ID, latent-style, and public API lookups containing quotes, apostrophes, and brackets
- document the fix in the unreleased 2.0.0 history

## Root cause

Style lookup embedded user-supplied values directly in XPath string literals. A name containing a double quote produced an invalid predicate, so the library could create a style it could not later retrieve.

## Upstream scope

This changes shared-core style lookup behavior and may also be suitable for `python-openxml/python-docx`.

## Verification

- `uv run pytest -q` — 2,377 passed on Python 3.13
- `uv run --python 3.9 pytest tests -q` — 2,377 passed
- `uv run behave --format progress --tags=-wip` — 72 features, 677 scenarios, 1,986 steps passed
- `uv run ruff check .`
- changed-file `uv run ruff format --check ...`
- `uv run mkdocs build`

Closes #121.
