### PR TITLE
fix: model w:shd per the schema, and write a valid w:val

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -83,7 +83,8 @@ Added
 - ``.docm`` macro-enabled document support, and ``.dotx``/``.dotm`` template support
 - Content controls — reading text wrapped in a ``w:sdt``
 - East Asian and complex-script typefaces, ``w:szCs``, character scaling, theme fonts
-- Paragraph and run shading, and paragraph outline level
+- Paragraph and run shading — ``shading_fill``, plus ``shading_pattern`` and
+  ``shading_color`` and the ``WD_SHADING_PATTERN`` enum — and paragraph outline level
 - Multi-column section layout
 - Alt text on pictures and inline shapes
 - ``_Row.dont_split``, and the merge extent and origin of a table cell
@@ -96,6 +97,12 @@ Added
 Fixed
 ~~~~~
 
+- ``w:shd`` is modelled correctly. The schema requires ``w:val`` and makes ``w:fill``
+  optional; this library required ``w:fill`` and never wrote ``w:val``, so it emitted
+  shading a validating consumer rejects and raised on the pattern shading Word writes
+  for most of its presets. Shading now carries an explicit ``w:val``, and a ``w:shd``
+  with a pattern but no fill reads as |None| rather than raising. A ``w:shd`` written by
+  an earlier version, with no ``w:val``, still reads.
 - Style and latent-style lookup now accepts names and style IDs containing quotes and
   other XPath metacharacters.
 - Documents with oversized attribute values, which the default ``lxml`` parser rejects,

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -103,6 +103,11 @@ Fixed
   for most of its presets. Shading now carries an explicit ``w:val``, and a ``w:shd``
   with a pattern but no fill reads as |None| rather than raising. A ``w:shd`` written by
   an earlier version, with no ``w:val``, still reads.
+- ``ST_HexColor`` accepts ``"auto"`` on assignment as well as on read. The schema type
+  is a union of an RGB triple and that literal, but only the read direction handled it,
+  so ``font.shading_fill = "auto"`` raised ``ValueError`` on a value the getter
+  documents and returns. ``w:color/@w:val`` is assignable as ``"auto"`` for the same
+  reason.
 - Style and latent-style lookup now accepts names and style IDs containing quotes and
   other XPath metacharacters.
 - Documents with oversized attribute values, which the default ``lxml`` parser rejects,

--- a/docs/user/text.md
+++ b/docs/user/text.md
@@ -322,6 +322,28 @@ font.shading_fill = "FFFF00"
 paragraph.paragraph_format.shading_fill = "EEEEEE"
 ```
 
+Word draws a *pattern* in a foreground colour over that fill. The usual case is no
+pattern at all, `WD_SHADING_PATTERN.CLEAR`, which is what the two assignments above
+produce and what leaves the fill as a plain background. The percentage patterns are how
+Word produces a tint of one colour over another:
+
+```python
+from docx.enum.text import WD_SHADING_PATTERN
+
+font.shading_fill = "FFFFFF"                        # -- background --
+font.shading_color = "FF0000"                       # -- pattern foreground --
+font.shading_pattern = WD_SHADING_PATTERN.PCT_25    # -- 25% red over white --
+```
+
+Setting `shading_pattern` to `None` removes the shading entirely, as does setting
+`shading_fill` to `None`.
+
+!!! note
+
+    A shading pattern is valid with no fill — `<w:shd w:val="pct25" w:color="FF0000"/>`
+    is what Word writes for several of its Shading presets. Reading `shading_fill` on
+    such a run returns `None` rather than raising.
+
 !!! note
 
     In 0.9.x, [`Font.highlight_color`][docx.text.font.Font.highlight_color] fell back to

--- a/src/docx/enum/text.py
+++ b/src/docx/enum/text.py
@@ -308,6 +308,142 @@ class WD_LINE_SPACING(BaseXmlEnum):
        change the line spacing proportionately."""
 
 
+class WD_SHADING_PATTERN(BaseXmlEnum):
+    """Specifies the pattern drawn over the background of shaded content.
+
+    The pattern is drawn in the shading *color* over the shading *fill*. The common
+    case is |CLEAR|, which draws no pattern and leaves the fill as a solid background.
+
+    * ISO/IEC 29500-1 §17.18.78 (`ST_Shd`)
+    """
+
+    NIL = (0, "nil", "No shading. Equivalent to no `w:shd` element at all.")
+    """No shading. Equivalent to no `w:shd` element at all."""
+
+    CLEAR = (1, "clear", "No pattern; the fill color forms a solid background.")
+    """No pattern; the fill color forms a solid background.
+
+    This is what Word writes for an ordinary background color, and what this library
+    writes when shading is applied without naming a pattern.
+    """
+
+    SOLID = (2, "solid", "The pattern color entirely covers the fill color.")
+    """The pattern color entirely covers the fill color.
+
+    Note the reversal: with |SOLID| the visible background is the shading *color*, not
+    the fill.
+    """
+
+    HORZ_STRIPE = (3, "horzStripe", "Horizontal stripes.")
+    """Horizontal stripes."""
+
+    VERT_STRIPE = (4, "vertStripe", "Vertical stripes.")
+    """Vertical stripes."""
+
+    REVERSE_DIAG_STRIPE = (5, "reverseDiagStripe", "Diagonal stripes, upward to right.")
+    """Diagonal stripes running upward to the right."""
+
+    DIAG_STRIPE = (6, "diagStripe", "Diagonal stripes, downward to right.")
+    """Diagonal stripes running downward to the right."""
+
+    HORZ_CROSS = (7, "horzCross", "A horizontal and vertical crosshatch.")
+    """A horizontal and vertical crosshatch."""
+
+    DIAG_CROSS = (8, "diagCross", "A diagonal crosshatch.")
+    """A diagonal crosshatch."""
+
+    THIN_HORZ_STRIPE = (9, "thinHorzStripe", "Narrow horizontal stripes.")
+    """Narrow horizontal stripes."""
+
+    THIN_VERT_STRIPE = (10, "thinVertStripe", "Narrow vertical stripes.")
+    """Narrow vertical stripes."""
+
+    THIN_REVERSE_DIAG_STRIPE = (
+        11,
+        "thinReverseDiagStripe",
+        "Narrow diagonal stripes, upward to right.",
+    )
+    """Narrow diagonal stripes running upward to the right."""
+
+    THIN_DIAG_STRIPE = (12, "thinDiagStripe", "Narrow diagonal stripes, downward to right.")
+    """Narrow diagonal stripes running downward to the right."""
+
+    THIN_HORZ_CROSS = (13, "thinHorzCross", "A narrow horizontal and vertical crosshatch.")
+    """A narrow horizontal and vertical crosshatch."""
+
+    THIN_DIAG_CROSS = (14, "thinDiagCross", "A narrow diagonal crosshatch.")
+    """A narrow diagonal crosshatch."""
+
+    PCT_5 = (15, "pct5", "5% of the pattern color over the fill color.")
+    """5% of the pattern color over the fill color."""
+
+    PCT_10 = (16, "pct10", "10% of the pattern color over the fill color.")
+    """10% of the pattern color over the fill color."""
+
+    PCT_12 = (17, "pct12", "12.5% of the pattern color over the fill color.")
+    """12.5% of the pattern color over the fill color."""
+
+    PCT_15 = (18, "pct15", "15% of the pattern color over the fill color.")
+    """15% of the pattern color over the fill color."""
+
+    PCT_20 = (19, "pct20", "20% of the pattern color over the fill color.")
+    """20% of the pattern color over the fill color."""
+
+    PCT_25 = (20, "pct25", "25% of the pattern color over the fill color.")
+    """25% of the pattern color over the fill color."""
+
+    PCT_30 = (21, "pct30", "30% of the pattern color over the fill color.")
+    """30% of the pattern color over the fill color."""
+
+    PCT_35 = (22, "pct35", "35% of the pattern color over the fill color.")
+    """35% of the pattern color over the fill color."""
+
+    PCT_37 = (23, "pct37", "37.5% of the pattern color over the fill color.")
+    """37.5% of the pattern color over the fill color."""
+
+    PCT_40 = (24, "pct40", "40% of the pattern color over the fill color.")
+    """40% of the pattern color over the fill color."""
+
+    PCT_45 = (25, "pct45", "45% of the pattern color over the fill color.")
+    """45% of the pattern color over the fill color."""
+
+    PCT_50 = (26, "pct50", "50% of the pattern color over the fill color.")
+    """50% of the pattern color over the fill color."""
+
+    PCT_55 = (27, "pct55", "55% of the pattern color over the fill color.")
+    """55% of the pattern color over the fill color."""
+
+    PCT_60 = (28, "pct60", "60% of the pattern color over the fill color.")
+    """60% of the pattern color over the fill color."""
+
+    PCT_62 = (29, "pct62", "62.5% of the pattern color over the fill color.")
+    """62.5% of the pattern color over the fill color."""
+
+    PCT_65 = (30, "pct65", "65% of the pattern color over the fill color.")
+    """65% of the pattern color over the fill color."""
+
+    PCT_70 = (31, "pct70", "70% of the pattern color over the fill color.")
+    """70% of the pattern color over the fill color."""
+
+    PCT_75 = (32, "pct75", "75% of the pattern color over the fill color.")
+    """75% of the pattern color over the fill color."""
+
+    PCT_80 = (33, "pct80", "80% of the pattern color over the fill color.")
+    """80% of the pattern color over the fill color."""
+
+    PCT_85 = (34, "pct85", "85% of the pattern color over the fill color.")
+    """85% of the pattern color over the fill color."""
+
+    PCT_87 = (35, "pct87", "87.5% of the pattern color over the fill color.")
+    """87.5% of the pattern color over the fill color."""
+
+    PCT_90 = (36, "pct90", "90% of the pattern color over the fill color.")
+    """90% of the pattern color over the fill color."""
+
+    PCT_95 = (37, "pct95", "95% of the pattern color over the fill color.")
+    """95% of the pattern color over the fill color."""
+
+
 class WD_TAB_ALIGNMENT(BaseXmlEnum):
     """Specifies the tab stop alignment to apply.
 

--- a/src/docx/oxml/simpletypes.py
+++ b/src/docx/oxml/simpletypes.py
@@ -10,7 +10,7 @@ schema.
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any, Tuple
+from typing import Any, Tuple, cast
 
 from docx.exceptions import InvalidXmlError
 from docx.shared import Emu, Length, RGBColor, Twips
@@ -337,6 +337,14 @@ class ST_FtnEdn(XsdStringEnumeration):
 
 
 class ST_HexColor(BaseStringType):
+    """`ST_HexColor`, a union of an RGB triple and the literal "auto".
+
+    `ref/xsd/wml.xsd:159` defines it as `<xsd:union memberTypes="ST_HexColorAuto
+    s:ST_HexColorRGB"/>`, so "auto" — meaning "let the consumer choose a colour that
+    contrasts with the background" — is as valid as a hex triple. Both directions
+    accept it; converting one way only would make a value readable and not writable.
+    """
+
     @classmethod
     def convert_from_xml(  # pyright: ignore[reportIncompatibleMethodOverride]
         cls, str_value: str
@@ -347,19 +355,23 @@ class ST_HexColor(BaseStringType):
 
     @classmethod
     def convert_to_xml(  # pyright: ignore[reportIncompatibleMethodOverride]
-        cls, value: RGBColor
+        cls, value: RGBColor | str
     ) -> str:
         """Keep alpha hex numerals all uppercase just for consistency."""
+        if value == ST_HexColorAuto.AUTO:
+            return ST_HexColorAuto.AUTO
         # expecting 3-tuple of ints in range 0-255
-        return "%02X%02X%02X" % value
+        return "%02X%02X%02X" % cast(RGBColor, value)
 
     @classmethod
     def validate(cls, value: Any) -> None:
-        # must be an RGBColor object ---
-        if not isinstance(value, RGBColor):
-            raise ValueError(
-                "rgb color value must be RGBColor object, got %s %s" % (type(value), value)
-            )
+        # must be an RGBColor object, or the string "auto" ---
+        if isinstance(value, RGBColor) or value == ST_HexColorAuto.AUTO:
+            return
+        raise ValueError(
+            'rgb color value must be an RGBColor object or "auto", got %s %s'
+            % (type(value), value)
+        )
 
 
 class ST_HexColorAuto(XsdStringEnumeration):

--- a/src/docx/oxml/text/font.py
+++ b/src/docx/oxml/text/font.py
@@ -7,7 +7,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable
 
 from docx.enum.dml import MSO_THEME_COLOR
-from docx.enum.text import WD_COLOR_INDEX, WD_FONT_HINT, WD_UNDERLINE
+from docx.enum.text import (
+    WD_COLOR_INDEX,
+    WD_FONT_HINT,
+    WD_SHADING_PATTERN,
+    WD_UNDERLINE,
+)
 from docx.oxml.ns import nsdecls
 from docx.oxml.parser import parse_xml
 from docx.oxml.simpletypes import (
@@ -65,9 +70,52 @@ class CT_Highlight(BaseOxmlElement):
 
 
 class CT_Shd(BaseOxmlElement):
-    """`w:shd` element, specifying the shading (background fill) behind content."""
+    """`w:shd` element, specifying the shading (background fill) behind content.
 
-    fill: RGBColor | str = RequiredAttribute("w:fill", ST_HexColor)
+    One class serves `w:rPr`, `w:pPr`, `w:tcPr` and `w:tblPr`; the element is identical
+    in all four.
+
+    `w:val` is the required attribute in the schema, naming the pattern drawn over the
+    background. It is modelled as optional so a `w:shd` written without it — which this
+    library itself did before 2.0.0 — reads as |None| rather than raising. Everything
+    written from here carries an explicit `w:val`.
+
+    It is deliberately not given a descriptor `default`; |OptionalAttribute| *removes*
+    an attribute assigned its default value, which would drop the `w:val` this class
+    exists to start writing.
+    """
+
+    val: WD_SHADING_PATTERN | None = OptionalAttribute("w:val", WD_SHADING_PATTERN)
+    color: RGBColor | str | None = OptionalAttribute("w:color", ST_HexColor)
+    fill: RGBColor | str | None = OptionalAttribute("w:fill", ST_HexColor)
+    themeColor: MSO_THEME_COLOR | None = OptionalAttribute("w:themeColor", MSO_THEME_COLOR)
+    themeTint: str | None = OptionalAttribute("w:themeTint", ST_String)
+    themeShade: str | None = OptionalAttribute("w:themeShade", ST_String)
+    themeFill: MSO_THEME_COLOR | None = OptionalAttribute("w:themeFill", MSO_THEME_COLOR)
+    themeFillTint: str | None = OptionalAttribute("w:themeFillTint", ST_String)
+    themeFillShade: str | None = OptionalAttribute("w:themeFillShade", ST_String)
+
+
+def _shd_val(shd: CT_Shd | None) -> WD_SHADING_PATTERN | None:
+    """The shading pattern `shd` specifies, or |None| when `shd` is |None|.
+
+    A `w:shd` carrying no `w:val` is out of schema but renders as a plain background,
+    so it is reported as |CLEAR| rather than |None| — |None| is reserved for "no
+    shading applied".
+    """
+    if shd is None:
+        return None
+    return WD_SHADING_PATTERN.CLEAR if shd.val is None else shd.val
+
+
+def _ensure_shd_val(shd: CT_Shd) -> None:
+    """Give `shd` an explicit `w:val`, which the schema requires, if it has none.
+
+    An existing value is left alone; setting a fill must not silently discard a pattern
+    the caller or Word put there.
+    """
+    if shd.val is None:
+        shd.val = WD_SHADING_PATTERN.CLEAR
 
 
 class CT_TextScale(BaseOxmlElement):
@@ -322,7 +370,11 @@ class CT_RPr(BaseOxmlElement):
 
     @property
     def shd_fill(self) -> RGBColor | str | None:
-        """Value of `./w:shd/@w:fill`, or |None| when no shading is applied."""
+        """Value of `./w:shd/@w:fill`, or |None| when there is none.
+
+        |None| both when there is no `w:shd` at all and when it carries a pattern but no
+        fill, which is valid — `<w:shd w:val="pct25" w:color="FF0000"/>` for instance.
+        """
         shd = self.shd
         if shd is None:
             return None
@@ -336,7 +388,40 @@ class CT_RPr(BaseOxmlElement):
         if isinstance(value, str) and value != "auto":
             value = RGBColor.from_string(value)
         shd = self.get_or_add_shd()
+        _ensure_shd_val(shd)
         shd.fill = value
+
+    @property
+    def shd_val(self) -> WD_SHADING_PATTERN | None:
+        """The `w:shd/@w:val` shading pattern, or |None| when no shading is applied."""
+        return _shd_val(self.shd)
+
+    @shd_val.setter
+    def shd_val(self, value: WD_SHADING_PATTERN | None) -> None:
+        if value is None:
+            self._remove_shd()
+            return
+        self.get_or_add_shd().val = value
+
+    @property
+    def shd_color(self) -> RGBColor | str | None:
+        """Value of `./w:shd/@w:color`, the pattern foreground, or |None|."""
+        shd = self.shd
+        if shd is None:
+            return None
+        return shd.color
+
+    @shd_color.setter
+    def shd_color(self, value: RGBColor | str | None) -> None:
+        if value is None:
+            if self.shd is not None:
+                self.shd.color = None
+            return
+        if isinstance(value, str) and value != "auto":
+            value = RGBColor.from_string(value)
+        shd = self.get_or_add_shd()
+        _ensure_shd_val(shd)
+        shd.color = value
 
     @property
     def w_val(self) -> int | None:

--- a/src/docx/oxml/text/parfmt.py
+++ b/src/docx/oxml/text/parfmt.py
@@ -7,11 +7,13 @@ from typing import TYPE_CHECKING, Callable
 from docx.enum.text import (
     WD_ALIGN_PARAGRAPH,
     WD_LINE_SPACING,
+    WD_SHADING_PATTERN,
     WD_TAB_ALIGNMENT,
     WD_TAB_LEADER,
 )
 from docx.oxml.shared import CT_DecimalNumber
 from docx.oxml.simpletypes import ST_SignedTwipsMeasure, ST_TwipsMeasure
+from docx.oxml.text.font import _ensure_shd_val, _shd_val
 from docx.oxml.xmlchemy import (
     BaseOxmlElement,
     OneOrMore,
@@ -144,7 +146,11 @@ class CT_PPr(BaseOxmlElement):
 
     @property
     def shd_fill(self) -> RGBColor | str | None:
-        """Value of `./w:shd/@w:fill`, or |None| when no shading is applied."""
+        """Value of `./w:shd/@w:fill`, or |None| when there is none.
+
+        |None| both when there is no `w:shd` at all and when it carries a pattern but no
+        fill, which is valid — `<w:shd w:val="pct25" w:color="FF0000"/>` for instance.
+        """
         shd = self.shd
         if shd is None:
             return None
@@ -157,7 +163,41 @@ class CT_PPr(BaseOxmlElement):
             return
         if isinstance(value, str) and value != "auto":
             value = RGBColor.from_string(value)
-        self.get_or_add_shd().fill = value
+        shd = self.get_or_add_shd()
+        _ensure_shd_val(shd)
+        shd.fill = value
+
+    @property
+    def shd_val(self) -> WD_SHADING_PATTERN | None:
+        """The `w:shd/@w:val` shading pattern, or |None| when no shading is applied."""
+        return _shd_val(self.shd)
+
+    @shd_val.setter
+    def shd_val(self, value: WD_SHADING_PATTERN | None) -> None:
+        if value is None:
+            self._remove_shd()
+            return
+        self.get_or_add_shd().val = value
+
+    @property
+    def shd_color(self) -> RGBColor | str | None:
+        """Value of `./w:shd/@w:color`, the pattern foreground, or |None|."""
+        shd = self.shd
+        if shd is None:
+            return None
+        return shd.color
+
+    @shd_color.setter
+    def shd_color(self, value: RGBColor | str | None) -> None:
+        if value is None:
+            if self.shd is not None:
+                self.shd.color = None
+            return
+        if isinstance(value, str) and value != "auto":
+            value = RGBColor.from_string(value)
+        shd = self.get_or_add_shd()
+        _ensure_shd_val(shd)
+        shd.color = value
 
     @property
     def first_line_indent(self) -> Length | None:

--- a/src/docx/text/font.py
+++ b/src/docx/text/font.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from docx.dml.color import ColorFormat
-from docx.enum.text import WD_FONT_HINT, WD_UNDERLINE
+from docx.enum.text import WD_FONT_HINT, WD_SHADING_PATTERN, WD_UNDERLINE
 from docx.shared import ElementProxy, Emu
 
 if TYPE_CHECKING:
@@ -334,6 +334,44 @@ class Font(ElementProxy):
     def shading_fill(self, value: RGBColor | str | None) -> None:
         rPr = self._element.get_or_add_rPr()
         rPr.shd_fill = value
+
+    @property
+    def shading_pattern(self) -> WD_SHADING_PATTERN | None:
+        """The pattern drawn over the shading behind the text of this run.
+
+        A |WD_SHADING_PATTERN| member, or |None| when no shading is applied. Word writes
+        |WD_SHADING_PATTERN.CLEAR| for an ordinary background color, which is what
+        `.shading_fill` produces on its own.
+
+        Assigning |None| removes the shading entirely, the same as assigning |None| to
+        `.shading_fill`.
+        """
+        rPr = self._element.rPr
+        if rPr is None:
+            return None
+        return rPr.shd_val
+
+    @shading_pattern.setter
+    def shading_pattern(self, value: WD_SHADING_PATTERN | None) -> None:
+        self._element.get_or_add_rPr().shd_val = value
+
+    @property
+    def shading_color(self) -> RGBColor | str | None:
+        """The foreground color of the shading pattern behind the text of this run.
+
+        An |RGBColor| value, the string "auto", or |None|. This is the color the
+        `.shading_pattern` is drawn *in*; `.shading_fill` is the color behind it. For
+        the usual |WD_SHADING_PATTERN.CLEAR| pattern nothing is drawn and this has no
+        visible effect.
+        """
+        rPr = self._element.rPr
+        if rPr is None:
+            return None
+        return rPr.shd_color
+
+    @shading_color.setter
+    def shading_color(self, value: RGBColor | str | None) -> None:
+        self._element.get_or_add_rPr().shd_color = value
 
     @property
     def no_proof(self) -> bool | None:

--- a/src/docx/text/parfmt.py
+++ b/src/docx/text/parfmt.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from docx.enum.text import WD_LINE_SPACING
+from docx.enum.text import WD_LINE_SPACING, WD_SHADING_PATTERN
 from docx.shared import ElementProxy, Emu, Length, Pt, Twips, lazyproperty
 from docx.text.tabstops import TabStops
 
@@ -200,6 +200,44 @@ class ParagraphFormat(ElementProxy):
     @shading_fill.setter
     def shading_fill(self, value) -> None:
         self._element.get_or_add_pPr().shd_fill = value
+
+    @property
+    def shading_pattern(self) -> WD_SHADING_PATTERN | None:
+        """The pattern drawn over the shading behind the whole paragraph.
+
+        A |WD_SHADING_PATTERN| member, or |None| when no shading is applied. Word writes
+        |WD_SHADING_PATTERN.CLEAR| for an ordinary background color, which is what
+        `.shading_fill` produces on its own.
+
+        Assigning |None| removes the shading entirely, the same as assigning |None| to
+        `.shading_fill`.
+        """
+        pPr = self._element.pPr
+        if pPr is None:
+            return None
+        return pPr.shd_val
+
+    @shading_pattern.setter
+    def shading_pattern(self, value: WD_SHADING_PATTERN | None) -> None:
+        self._element.get_or_add_pPr().shd_val = value
+
+    @property
+    def shading_color(self):
+        """The foreground color of the shading pattern behind this paragraph.
+
+        An |RGBColor| value, the string "auto", or |None|. This is the color the
+        `.shading_pattern` is drawn *in*; `.shading_fill` is the color behind it. For
+        the usual |WD_SHADING_PATTERN.CLEAR| pattern nothing is drawn and this has no
+        visible effect.
+        """
+        pPr = self._element.pPr
+        if pPr is None:
+            return None
+        return pPr.shd_color
+
+    @shading_color.setter
+    def shading_color(self, value) -> None:
+        self._element.get_or_add_pPr().shd_color = value
 
     @property
     def page_break_before(self):

--- a/tests/text/test_font.py
+++ b/tests/text/test_font.py
@@ -10,7 +10,13 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 
 from docx.dml.color import ColorFormat
-from docx.enum.text import WD_COLOR, WD_COLOR_INDEX, WD_FONT_HINT, WD_UNDERLINE
+from docx.enum.text import (
+    WD_COLOR,
+    WD_COLOR_INDEX,
+    WD_FONT_HINT,
+    WD_SHADING_PATTERN,
+    WD_UNDERLINE,
+)
 from docx.oxml.text.run import CT_R
 from docx.shared import Emu, Length, Pt, RGBColor
 from docx.text.font import Font
@@ -159,8 +165,12 @@ class DescribeFont:
         [
             ("w:r", None),
             ("w:r/w:rPr", None),
+            ("w:r/w:rPr/w:shd{w:val=clear,w:fill=FF0000}", RGBColor(0xFF, 0x00, 0x00)),
+            ("w:r/w:rPr/w:shd{w:val=clear,w:fill=auto}", "auto"),
+            # -- a `w:shd` written before 2.0.0, with no `w:val`, still reads --
             ("w:r/w:rPr/w:shd{w:fill=FF0000}", RGBColor(0xFF, 0x00, 0x00)),
-            ("w:r/w:rPr/w:shd{w:fill=auto}", "auto"),
+            # -- a pattern with no fill is valid and reports no fill rather than raising --
+            ("w:r/w:rPr/w:shd{w:val=pct25,w:color=FF0000}", None),
         ],
     )
     def it_knows_its_shading_fill(self, r_cxml: str, expected_value: object):
@@ -168,12 +178,80 @@ class DescribeFont:
         assert font.shading_fill == expected_value
 
     @pytest.mark.parametrize(
+        ("r_cxml", "expected_value"),
+        [
+            ("w:r", None),
+            ("w:r/w:rPr", None),
+            ("w:r/w:rPr/w:shd{w:val=clear,w:fill=FF0000}", WD_SHADING_PATTERN.CLEAR),
+            ("w:r/w:rPr/w:shd{w:val=pct25}", WD_SHADING_PATTERN.PCT_25),
+            ("w:r/w:rPr/w:shd{w:val=thinDiagCross}", WD_SHADING_PATTERN.THIN_DIAG_CROSS),
+            # -- `w:shd` with no `w:val` is out of schema but renders as a plain
+            # -- background, so it reads as CLEAR rather than None --
+            ("w:r/w:rPr/w:shd{w:fill=FF0000}", WD_SHADING_PATTERN.CLEAR),
+        ],
+    )
+    def it_knows_its_shading_pattern(self, r_cxml: str, expected_value: object):
+        font = Font(cast(CT_R, element(r_cxml)))
+        assert font.shading_pattern == expected_value
+
+    @pytest.mark.parametrize(
         ("r_cxml", "value", "expected_r_cxml"),
         [
-            ("w:r", RGBColor(0xFF, 0x00, 0x00), "w:r/w:rPr/w:shd{w:fill=FF0000}"),
-            ("w:r", "00FF00", "w:r/w:rPr/w:shd{w:fill=00FF00}"),
-            ("w:r", "#0000FF", "w:r/w:rPr/w:shd{w:fill=0000FF}"),
-            ("w:r/w:rPr/w:shd{w:fill=FF0000}", None, "w:r/w:rPr"),
+            ("w:r", WD_SHADING_PATTERN.PCT_25, "w:r/w:rPr/w:shd{w:val=pct25}"),
+            # -- CLEAR must be written, not dropped as an OptionalAttribute default --
+            ("w:r", WD_SHADING_PATTERN.CLEAR, "w:r/w:rPr/w:shd{w:val=clear}"),
+            (
+                "w:r/w:rPr/w:shd{w:val=clear,w:fill=FF0000}",
+                WD_SHADING_PATTERN.DIAG_STRIPE,
+                "w:r/w:rPr/w:shd{w:val=diagStripe,w:fill=FF0000}",
+            ),
+            ("w:r/w:rPr/w:shd{w:val=pct25}", None, "w:r/w:rPr"),
+        ],
+    )
+    def it_can_change_its_shading_pattern(
+        self, r_cxml: str, value: object, expected_r_cxml: str
+    ):
+        font = Font(cast(CT_R, element(r_cxml)))
+        expected_xml = xml(expected_r_cxml)
+
+        font.shading_pattern = value  # pyright: ignore[reportAttributeAccessIssue]
+
+        assert font._element.xml == expected_xml
+
+    @pytest.mark.parametrize(
+        ("r_cxml", "value", "expected_r_cxml"),
+        [
+            ("w:r", "FF0000", "w:r/w:rPr/w:shd{w:val=clear,w:color=FF0000}"),
+            (
+                "w:r/w:rPr/w:shd{w:val=pct25}",
+                RGBColor(0x00, 0xFF, 0x00),
+                "w:r/w:rPr/w:shd{w:val=pct25,w:color=00FF00}",
+            ),
+            ("w:r/w:rPr/w:shd{w:val=pct25,w:color=FF0000}", None, "w:r/w:rPr/w:shd{w:val=pct25}"),
+        ],
+    )
+    def it_can_change_its_shading_color(self, r_cxml: str, value: object, expected_r_cxml: str):
+        font = Font(cast(CT_R, element(r_cxml)))
+        expected_xml = xml(expected_r_cxml)
+
+        font.shading_color = value  # pyright: ignore[reportAttributeAccessIssue]
+
+        assert font._element.xml == expected_xml
+
+    @pytest.mark.parametrize(
+        ("r_cxml", "value", "expected_r_cxml"),
+        [
+            # -- `w:val` is required by the schema; a fill alone is not a valid `w:shd` --
+            ("w:r", RGBColor(0xFF, 0x00, 0x00), "w:r/w:rPr/w:shd{w:val=clear,w:fill=FF0000}"),
+            ("w:r", "00FF00", "w:r/w:rPr/w:shd{w:val=clear,w:fill=00FF00}"),
+            ("w:r", "#0000FF", "w:r/w:rPr/w:shd{w:val=clear,w:fill=0000FF}"),
+            ("w:r/w:rPr/w:shd{w:val=clear,w:fill=FF0000}", None, "w:r/w:rPr"),
+            # -- an existing pattern is preserved, not overwritten with "clear" --
+            (
+                "w:r/w:rPr/w:shd{w:val=pct25}",
+                "00FF00",
+                "w:r/w:rPr/w:shd{w:val=pct25,w:fill=00FF00}",
+            ),
         ],
     )
     def it_can_change_its_shading_fill(self, r_cxml: str, value: object, expected_r_cxml: str):

--- a/tests/text/test_font.py
+++ b/tests/text/test_font.py
@@ -246,6 +246,9 @@ class DescribeFont:
             ("w:r", "00FF00", "w:r/w:rPr/w:shd{w:val=clear,w:fill=00FF00}"),
             ("w:r", "#0000FF", "w:r/w:rPr/w:shd{w:val=clear,w:fill=0000FF}"),
             ("w:r/w:rPr/w:shd{w:val=clear,w:fill=FF0000}", None, "w:r/w:rPr"),
+            # -- "auto" is half of the ST_HexColor union and must survive a round trip;
+            # -- it was readable but not assignable --
+            ("w:r", "auto", "w:r/w:rPr/w:shd{w:val=clear,w:fill=auto}"),
             # -- an existing pattern is preserved, not overwritten with "clear" --
             (
                 "w:r/w:rPr/w:shd{w:val=pct25}",

--- a/tests/text/test_parfmt.py
+++ b/tests/text/test_parfmt.py
@@ -78,6 +78,8 @@ class DescribeParagraphFormat:
             ),
             ("w:p", "#FF0000", "w:p/w:pPr/w:shd{w:val=clear,w:fill=FF0000}"),
             ("w:p/w:pPr/w:shd{w:val=clear,w:fill=C0C0C0}", None, "w:p/w:pPr"),
+            # -- "auto" is half of the ST_HexColor union; readable but not assignable --
+            ("w:p", "auto", "w:p/w:pPr/w:shd{w:val=clear,w:fill=auto}"),
             # -- an existing pattern is preserved, not overwritten with "clear" --
             (
                 "w:p/w:pPr/w:shd{w:val=pct25}",

--- a/tests/text/test_parfmt.py
+++ b/tests/text/test_parfmt.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_LINE_SPACING
+from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_LINE_SPACING, WD_SHADING_PATTERN
 from docx.shared import Pt, RGBColor
 from docx.text.parfmt import ParagraphFormat
 from docx.text.tabstops import TabStops
@@ -55,8 +55,12 @@ class DescribeParagraphFormat:
         [
             ("w:p", None),
             ("w:p/w:pPr", None),
+            ("w:p/w:pPr/w:shd{w:val=clear,w:fill=C0C0C0}", RGBColor(0xC0, 0xC0, 0xC0)),
+            ("w:p/w:pPr/w:shd{w:val=clear,w:fill=auto}", "auto"),
+            # -- a `w:shd` written before 2.0.0, with no `w:val`, still reads --
             ("w:p/w:pPr/w:shd{w:fill=C0C0C0}", RGBColor(0xC0, 0xC0, 0xC0)),
-            ("w:p/w:pPr/w:shd{w:fill=auto}", "auto"),
+            # -- a pattern with no fill is valid and reports no fill rather than raising --
+            ("w:p/w:pPr/w:shd{w:val=pct25,w:color=FF0000}", None),
         ],
     )
     def it_knows_its_shading_fill(self, p_cxml, expected_value):
@@ -66,9 +70,20 @@ class DescribeParagraphFormat:
     @pytest.mark.parametrize(
         ("p_cxml", "value", "expected_p_cxml"),
         [
-            ("w:p", RGBColor(0xC0, 0xC0, 0xC0), "w:p/w:pPr/w:shd{w:fill=C0C0C0}"),
-            ("w:p", "#FF0000", "w:p/w:pPr/w:shd{w:fill=FF0000}"),
-            ("w:p/w:pPr/w:shd{w:fill=C0C0C0}", None, "w:p/w:pPr"),
+            # -- `w:val` is required by the schema; a fill alone is not a valid `w:shd` --
+            (
+                "w:p",
+                RGBColor(0xC0, 0xC0, 0xC0),
+                "w:p/w:pPr/w:shd{w:val=clear,w:fill=C0C0C0}",
+            ),
+            ("w:p", "#FF0000", "w:p/w:pPr/w:shd{w:val=clear,w:fill=FF0000}"),
+            ("w:p/w:pPr/w:shd{w:val=clear,w:fill=C0C0C0}", None, "w:p/w:pPr"),
+            # -- an existing pattern is preserved, not overwritten with "clear" --
+            (
+                "w:p/w:pPr/w:shd{w:val=pct25}",
+                "C0C0C0",
+                "w:p/w:pPr/w:shd{w:val=pct25,w:fill=C0C0C0}",
+            ),
         ],
     )
     def it_can_change_its_shading_fill(self, p_cxml, value, expected_p_cxml):
@@ -79,6 +94,45 @@ class DescribeParagraphFormat:
 
         assert paragraph_format._element.xml == expected_xml
 
+    @pytest.mark.parametrize(
+        ("p_cxml", "expected_value"),
+        [
+            ("w:p", None),
+            ("w:p/w:pPr", None),
+            ("w:p/w:pPr/w:shd{w:val=clear,w:fill=C0C0C0}", WD_SHADING_PATTERN.CLEAR),
+            ("w:p/w:pPr/w:shd{w:val=pct25}", WD_SHADING_PATTERN.PCT_25),
+            ("w:p/w:pPr/w:shd{w:fill=C0C0C0}", WD_SHADING_PATTERN.CLEAR),
+        ],
+    )
+    def it_knows_its_shading_pattern(self, p_cxml, expected_value):
+        paragraph_format = ParagraphFormat(element(p_cxml))
+        assert paragraph_format.shading_pattern == expected_value
+
+    @pytest.mark.parametrize(
+        ("p_cxml", "value", "expected_p_cxml"),
+        [
+            ("w:p", WD_SHADING_PATTERN.PCT_25, "w:p/w:pPr/w:shd{w:val=pct25}"),
+            ("w:p", WD_SHADING_PATTERN.CLEAR, "w:p/w:pPr/w:shd{w:val=clear}"),
+            ("w:p/w:pPr/w:shd{w:val=pct25}", None, "w:p/w:pPr"),
+        ],
+    )
+    def it_can_change_its_shading_pattern(self, p_cxml, value, expected_p_cxml):
+        paragraph_format = ParagraphFormat(element(p_cxml))
+        expected_xml = xml(expected_p_cxml)
+
+        paragraph_format.shading_pattern = value
+
+        assert paragraph_format._element.xml == expected_xml
+
+    def it_can_change_its_shading_color(self):
+        paragraph_format = ParagraphFormat(element("w:p/w:pPr/w:shd{w:val=pct25}"))
+
+        paragraph_format.shading_color = "FF0000"
+
+        assert paragraph_format._element.xml == xml(
+            "w:p/w:pPr/w:shd{w:val=pct25,w:color=FF0000}"
+        )
+
     def it_inserts_shading_in_schema_order(self):
         """`w:shd` must precede `w:spacing`, or Word rejects the document."""
         paragraph_format = ParagraphFormat(element("w:p/w:pPr/w:spacing{w:after=240}"))
@@ -86,7 +140,7 @@ class DescribeParagraphFormat:
         paragraph_format.shading_fill = "C0C0C0"
 
         assert paragraph_format._element.xml == xml(
-            "w:p/w:pPr/(w:shd{w:fill=C0C0C0},w:spacing{w:after=240})"
+            "w:p/w:pPr/(w:shd{w:val=clear,w:fill=C0C0C0},w:spacing{w:after=240})"
         )
 
     def it_knows_its_alignment_value(self, alignment_get_fixture):


### PR DESCRIPTION
Closes #103.

`CT_Shd` modelled exactly one attribute, `w:fill`, as required. `ref/xsd/wml.xsd:467` says `w:val` is the required one and `w:fill` is optional, so both halves misbehaved.

### We wrote invalid XML

`font.shading_fill = "FF0000"` emitted `<w:shd w:fill="FF0000"/>` with no `w:val`. A validating consumer rejects that; Word's tolerance is not something to rely on for output we generate.

### We raised on valid input

`<w:shd w:val="pct25" w:color="FF0000"/>` is a legal 25% pattern fill and what Word writes for most of its Shading presets. Reading it raised `InvalidXmlError`.

### Changes

- `WD_SHADING_PATTERN` over the full `ST_Shd` value list — all 38 members, checked against the schema in a test
- `w:color` and the six `theme*` attributes modelled
- `shading_pattern` and `shading_color` on both `Font` and `ParagraphFormat`
- setting a fill preserves an existing pattern rather than resetting it to `clear`

`w:val` is modelled as *optional* rather than required, deliberately, so a `w:shd` written by an earlier version of this library still reads instead of raising. Everything written from here carries an explicit `w:val`. It gets no descriptor `default` either — `OptionalAttribute` *removes* an attribute assigned its default value, which would drop the `w:val` this change exists to start writing.

### Also fixed here

`ST_HexColor` accepted `"auto"` on read and rejected it on assignment, so `font.shading_fill = "auto"` raised on a value the getter documents and returns. The schema type is a union of an RGB triple and that literal. Same defect class, same API, found while reviewing this branch.

### Verification

Generated `word/document.xml` validated against `ref/xsd/`: the shading cases fail on `main` and pass here. The expected-XML assertions in the existing tests were updated to the valid form rather than weakened.
