### PR TITLE
fix: resolve style names case-insensitively when the exact match fails

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -96,6 +96,13 @@ Added
 Fixed
 ~~~~~
 
+- Style lookup matches case-insensitively when an exact match fails. A built-in style
+  has two spellings — the UI name ("Heading 1") and the internal name Word stores
+  ("heading 1") — and documents from other generators routinely store the UI casing,
+  which made the style present but unreachable: ``add_heading()`` and every
+  ``style=`` assignment raised ``KeyError`` on a document that opened fine.
+  ``name in styles`` now resolves exactly as ``styles[name]`` does. Style *definitions*
+  are unchanged on save; only lookup is tolerant.
 - Style and latent-style lookup now accepts names and style IDs containing quotes and
   other XPath metacharacters.
 - Documents with oversized attribute values, which the default ``lxml`` parser rejects,

--- a/src/docx/oxml/styles.py
+++ b/src/docx/oxml/styles.py
@@ -367,9 +367,29 @@ class CT_Styles(BaseOxmlElement):
     def get_by_name(self, name: str) -> CT_Style | None:
         """`w:style` child with `w:name` grandchild having value `name`.
 
+        Matched exactly first, then case-insensitively. Word treats style names as
+        case-insensitive, and a built-in style has two spellings — the UI name
+        ("Heading 1") and the internal name Word stores ("heading 1"). Documents
+        written by other generators routinely store the UI casing, and without the
+        second pass the style is present but unreachable.
+
+        The exact pass runs first so that a document containing both spellings resolves
+        to the one asked for rather than to whichever comes first.
+
         |None| if not found.
         """
-        return next(iter(self.xpath("w:style[w:name/@w:val=$name]", name=name)), None)
+        exact = next(iter(self.xpath("w:style[w:name/@w:val=$name]", name=name)), None)
+        if exact is not None:
+            return exact
+
+        # -- no XPath 1.0 lower-case function, so fold in Python. Only reached when the
+        # -- exact match fails, which for a Word-authored document is never. --
+        folded = name.lower()
+        for style in self.xpath("w:style"):
+            style_name = style.name_val
+            if style_name is not None and style_name.lower() == folded:
+                return style
+        return None
 
     def _iter_styles(self):
         """Generate each of the `w:style` child elements in document order."""

--- a/src/docx/styles/styles.py
+++ b/src/docx/styles/styles.py
@@ -29,9 +29,13 @@ class Styles(ElementProxy):
         self._doc_part = part
 
     def __contains__(self, name):
-        """Enables `in` operator on style name."""
-        internal_name = BabelFish.ui2internal(name)
-        return any(style.name_val == internal_name for style in self._element.style_lst)
+        """Enables `in` operator on style name.
+
+        Resolved exactly as `__getitem__` resolves it, minus the deprecated lookup by
+        style id — a `__contains__` that disagrees with the subscript is worse than
+        either answer on its own.
+        """
+        return self._element.get_by_name(BabelFish.ui2internal(name)) is not None
 
     def __getitem__(self, key: str):
         """Enables dictionary-style access by UI name.

--- a/tests/styles/test_styles.py
+++ b/tests/styles/test_styles.py
@@ -49,6 +49,48 @@ class DescribeStyles:
 
         assert styles[name]._element is added_style._element
 
+    @pytest.mark.parametrize(
+        ("stored_name", "key"),
+        [
+            # -- what Word writes, asked for by its UI name --
+            ("heading 1", "Heading 1"),
+            # -- what several other generators write; the case #110 is about --
+            ("Heading 1", "Heading 1"),
+            ("Heading 1", "heading 1"),
+            ("HEADING 1", "Heading 1"),
+            # -- casing tolerance is not limited to the built-in aliases --
+            ("Foo Bar", "foo bar"),
+        ],
+    )
+    def it_finds_a_built_in_style_whichever_casing_the_document_stores(
+        self, stored_name: str, key: str
+    ):
+        styles = Styles(
+            element("w:styles/w:style{w:type=paragraph}/w:name{w:val=%s}" % stored_name)
+        )
+
+        assert key in styles
+        assert styles[key]._element is styles._element.style_lst[0]
+
+    def it_prefers_an_exact_name_match_over_a_case_insensitive_one(self):
+        """A document carrying both spellings must resolve to the one asked for."""
+        styles = Styles(
+            element(
+                "w:styles/(w:style{w:type=paragraph}/w:name{w:val=Heading 1},"
+                "w:style{w:type=paragraph}/w:name{w:val=heading 1})"
+            )
+        )
+
+        assert styles["heading 1"]._element is styles._element.style_lst[1]
+
+    def it_does_not_report_a_style_it_cannot_return(self):
+        """`in` and `[]` must agree; a `__contains__` that lies is worse than either."""
+        styles = Styles(element("w:styles/w:style{w:type=paragraph}/w:name{w:val=heading 1}"))
+
+        assert "Heading 2" not in styles
+        with pytest.raises(KeyError):
+            styles["Heading 2"]
+
     def it_raises_on_style_not_found(self, get_raises_fixture):
         styles, key = get_raises_fixture
         with pytest.raises(KeyError):
@@ -179,6 +221,9 @@ class DescribeStyles:
         name, name_, style_type, builtin = request.param
         styles = Styles(styles_elm_)
         _getitem_.return_value = None
+        # -- `add_style()` tests for a duplicate with `in`, which resolves through
+        # -- `get_by_name()`; None is "no style of that name is present" --
+        styles_elm_.get_by_name.return_value = None
         styles_elm_.add_style_of_type.return_value = style_elm_
         StyleFactory_.return_value = style_
         return (


### PR DESCRIPTION
Closes #110.

A built-in style has two spellings: the UI name ("Heading 1") and the internal name Word stores in `styles.xml` ("heading 1"). `BabelFish` translates between them and `get_by_name()` then matched exactly — right for documents Word wrote, wrong for the many generators that store the UI casing.

The style was present in the document and unreachable:

```python
>>> d = Document("from-some-other-tool.docx")
>>> d.add_heading("Chapter 1", 1)
KeyError: "no style with name 'Heading 1'"
```

`add_heading()`, `add_paragraph(style=...)` and every `.style = "..."` assignment go through that path, so a document that opened fine could not have a heading added to it. Three people have filed this upstream (PRs #958, #1043, #239).

### Changes

- `get_by_name()` falls back to a case-insensitive scan when the exact match fails. Exact runs first, so a document carrying both spellings still resolves to the one asked for. The scan is only reached when the exact match fails, which for a Word-authored document is never.
- `Styles.__contains__` resolves through the same call rather than its own comparison, so `in` and `[]` can no longer disagree.

Writes are untouched: `add_style()` still stores the internal name, so generated documents keep the built-in identity Word's style gallery matches on.

The untranslated-key attempt the issue also proposed turned out to be unnecessary — folding case subsumes it, since the two spellings differ only in case.

### Verification

Regression tests are built from a real `styles.xml` carrying the UI casing rather than a mock, as the issue asked. Also verified end to end that opening such a document, adding headings and saving leaves the existing style definitions untouched.
