### PR TITLE
fix: look through w:smartTag and w:customXml when reading content

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,8 +50,11 @@ Breaking changes
   Word writes a ``w:smartTag`` around a recognised date, name or place, and its ``w:r``
   children are ordinary runs one level down — previously invisible, so the text was
   silently dropped and the run missing from ``.runs``. ``Paragraph.original_text``
-  reads them too. Text inside a text box (``w:txbxContent``) is still not included;
-  that is a separate container rather than a transparent wrapper.
+  reads them too. A block-level ``w:customXml``, which wraps whole paragraphs and
+  tables, is looked through as well — its content was previously absent from
+  ``Document.paragraphs`` and ``.tables`` altogether. Text inside a text box
+  (``w:txbxContent``) is still not included; that is a separate container rather than a
+  transparent wrapper.
 
 Added
 ~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,6 +46,12 @@ Breaking changes
   ``Paragraph.runs`` likewise now includes runs inside a ``w:ins``.
 - ``Paragraph.text`` also now includes the cached result of a ``w:fldSimple`` — a page
   number or cross-reference displayed by such a field was previously missing from it.
+- ``Paragraph.text`` and ``.runs`` now look through ``w:smartTag`` and ``w:customXml``.
+  Word writes a ``w:smartTag`` around a recognised date, name or place, and its ``w:r``
+  children are ordinary runs one level down — previously invisible, so the text was
+  silently dropped and the run missing from ``.runs``. ``Paragraph.original_text``
+  reads them too. Text inside a text box (``w:txbxContent``) is still not included;
+  that is a separate container rather than a transparent wrapper.
 
 Added
 ~~~~~

--- a/src/docx/oxml/revision.py
+++ b/src/docx/oxml/revision.py
@@ -31,6 +31,7 @@ import datetime as dt
 from typing import TYPE_CHECKING, Iterator, List, cast
 
 from docx.oxml.ns import qn
+from docx.oxml.sdt import TRANSPARENT_WRAPPER_TAGS
 from docx.oxml.simpletypes import ST_DecimalNumber, ST_String
 from docx.oxml.xmlchemy import BaseOxmlElement, OptionalAttribute
 
@@ -149,7 +150,7 @@ def iter_original_run_content(element: BaseOxmlElement) -> Iterator[CT_R | CT_Hy
             yield cast("CT_R | CT_Hyperlink", child)
         elif tag in inserted:
             continue  # -- not there before the revision --
-        elif tag in deleted or tag == qn("w:fldSimple"):
+        elif tag in deleted or tag == qn("w:fldSimple") or tag in TRANSPARENT_WRAPPER_TAGS:
             yield from iter_original_run_content(cast(BaseOxmlElement, child))
         elif tag == qn("w:sdt"):
             sdtContent = child.find(qn("w:sdtContent"))

--- a/src/docx/oxml/sdt.py
+++ b/src/docx/oxml/sdt.py
@@ -70,10 +70,16 @@ def iter_block_content(element: BaseOxmlElement) -> Iterator[CT_P | CT_Tbl]:
     A `w:sdt` child is looked through rather than skipped: the block-level content of
     its `w:sdtContent` is generated in its place, recursively, so a content control
     nested in another content control is seen as well.
+
+    So is a `w:customXml`, which the schema defines in a block-level flavour
+    (`CT_CustomXmlBlock`) as well as the run-level one — it wraps whole paragraphs and
+    tables, and skipping it drops them from the document entirely.
     """
     for child in element.iterchildren():
         if child.tag in (qn("w:p"), qn("w:tbl")):
             yield cast("CT_P | CT_Tbl", child)
+        elif child.tag in TRANSPARENT_WRAPPER_TAGS:
+            yield from iter_block_content(cast("BaseOxmlElement", child))
         elif child.tag == qn("w:sdt"):
             sdtContent = child.find(qn("w:sdtContent"))
             if sdtContent is not None:

--- a/src/docx/oxml/sdt.py
+++ b/src/docx/oxml/sdt.py
@@ -44,9 +44,21 @@ _CONTROL_TYPE_TAGS = (
 )
 
 
+# -- Wrappers that contribute nothing of their own and whose `w:r` children are ordinary
+# -- runs one level down. `w:smartTag` is what Word puts around a recognised entity — a
+# -- date, a name, a place; Word 2003 wrote them freely and they still round-trip
+# -- through modern Word. `w:customXml` has the same shape. Both are transparent under
+# -- either reading of a revised document, so they are shared with the original-text
+# -- walk in `docx.oxml.revision` rather than listed twice. --
+TRANSPARENT_WRAPPER_TAGS = (qn("w:smartTag"), qn("w:customXml"))
+
 # -- run-level wrappers whose children are part of the text as the document now reads:
 # -- a field's cached result, and an insertion --
-_LOOK_THROUGH_TAGS = (qn("w:fldSimple"), qn("w:ins"), qn("w:moveTo"))
+_LOOK_THROUGH_TAGS = (
+    qn("w:fldSimple"),
+    qn("w:ins"),
+    qn("w:moveTo"),
+) + TRANSPARENT_WRAPPER_TAGS
 
 # -- and one whose children are not: deleted text --
 _SKIP_TAGS = (qn("w:del"), qn("w:moveFrom"))

--- a/tests/oxml/test_sdt.py
+++ b/tests/oxml/test_sdt.py
@@ -43,6 +43,30 @@ class DescribeBlockContentWalking:
 
         assert actual == expected
 
+    @pytest.mark.parametrize(
+        ("body_cxml", "expected"),
+        [
+            # -- `CT_CustomXmlBlock` wraps whole paragraphs and tables --
+            ("w:body/w:customXml/w:p", ["p"]),
+            ("w:body/(w:p,w:customXml/(w:p,w:tbl),w:p)", ["p", "p", "tbl", "p"]),
+            # -- nesting, and composing with a content control --
+            ("w:body/w:customXml/w:customXml/w:p", ["p"]),
+            ("w:body/w:sdt/w:sdtContent/w:customXml/w:p", ["p"]),
+            ("w:body/w:customXml/w:sdt/w:sdtContent/w:p", ["p"]),
+            # -- an empty wrapper contributes nothing rather than raising --
+            ("w:body/(w:customXml,w:p)", ["p"]),
+        ],
+    )
+    def it_looks_through_a_block_level_custom_xml_wrapper(
+        self, body_cxml: str, expected: list[str]
+    ):
+        """Skipping it would drop the paragraphs it wraps from the document entirely."""
+        body = cast(BaseOxmlElement, element(body_cxml))
+
+        actual = [e.tag.split("}")[1] for e in iter_block_content(body)]
+
+        assert actual == expected
+
     def it_leaves_a_sectPr_and_other_non_content_children_out(self):
         body = cast(BaseOxmlElement, element("w:body/(w:p,w:sectPr)"))
 

--- a/tests/oxml/test_sdt.py
+++ b/tests/oxml/test_sdt.py
@@ -71,6 +71,36 @@ class DescribeRunContentWalking:
 
         assert actual == expected
 
+    @pytest.mark.parametrize(
+        ("p_cxml", "expected"),
+        [
+            # -- the runs Word wraps around a recognised date, name or place --
+            ("w:p/(w:r,w:smartTag/w:r,w:r)", ["r", "r", "r"]),
+            ("w:p/w:smartTag/(w:r,w:r)", ["r", "r"]),
+            # -- Word does nest them --
+            ("w:p/w:smartTag/w:smartTag/w:r", ["r"]),
+            # -- `w:customXml` has the same shape --
+            ("w:p/(w:r,w:customXml/w:r)", ["r", "r"]),
+            ("w:p/w:customXml/w:smartTag/w:r", ["r"]),
+            # -- a hyperlink inside one is still a hyperlink --
+            ("w:p/w:smartTag/w:hyperlink", ["hyperlink"]),
+            # -- composes with the wrappers already looked through --
+            ("w:p/w:smartTag/w:sdt/w:sdtContent/w:r", ["r"]),
+            ("w:p/w:smartTag/w:ins/w:r", ["r"]),
+            # -- and a deletion inside one is still skipped --
+            ("w:p/w:smartTag/w:del/w:r", []),
+        ],
+    )
+    def it_looks_through_a_smart_tag_and_custom_xml_wrapper(
+        self, p_cxml: str, expected: list[str]
+    ):
+        """`w:smartTag` and `w:customXml` are transparent; their runs are ordinary runs."""
+        p = cast(BaseOxmlElement, element(p_cxml))
+
+        actual = [e.tag.split("}")[1] for e in iter_run_content(p)]
+
+        assert actual == expected
+
 
 class DescribeCT_Sdt:
     """Unit-test suite for `docx.oxml.sdt.CT_Sdt`."""

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -83,6 +83,19 @@ class DescribeRevisionTextModel:
 
         assert paragraph.text == paragraph.original_text == "plain"
 
+    def it_reads_both_sides_of_a_revision_inside_a_smart_tag(self):
+        """A `w:smartTag` is transparent under either reading, not just the current one."""
+        document = _document(
+            '<w:p><w:smartTag w:element="date">'
+            '<w:ins w:id="1" w:author="Ada"><w:r><w:t>new</w:t></w:r></w:ins>'
+            '<w:del w:id="2" w:author="Ada"><w:r><w:delText>old</w:delText></w:r></w:del>'
+            "</w:smartTag></w:p>"
+        )
+        paragraph = document.paragraphs[0]
+
+        assert paragraph.text == "new"
+        assert paragraph.original_text == "old"
+
     def it_includes_inserted_runs_in_the_run_collection(self):
         document = _document(_REVISED_PARAGRAPH)
 

--- a/tests/text/test_paragraph.py
+++ b/tests/text/test_paragraph.py
@@ -188,6 +188,21 @@ class DescribeParagraph:
         assert len(runs) == 4
         assert [run._r for run in runs] == paragraph._p.xpath(".//w:r")
 
+    def it_sees_the_runs_inside_a_smart_tag(self):
+        """`w:smartTag` wraps a recognised entity; its runs are ordinary runs."""
+        paragraph = Paragraph(
+            element('w:p/(w:r/w:t"A ",w:smartTag/w:r/w:t"TAGGED",w:r/w:t" B")'), None
+        )
+
+        assert paragraph.text == "A TAGGED B"
+        assert [run._r for run in paragraph.runs] == paragraph._p.xpath(".//w:r")
+
+    def and_it_sees_the_runs_inside_a_custom_xml_wrapper(self):
+        paragraph = Paragraph(element('w:p/w:customXml/w:r/w:t"CUSTOM"'), None)
+
+        assert paragraph.text == "CUSTOM"
+        assert len(paragraph.runs) == 1
+
     def it_can_add_a_run_to_itself(self, add_run_fixture):
         paragraph, text, style, style_prop_, expected_xml = add_run_fixture
         run = paragraph.add_run(text, style)


### PR DESCRIPTION
Addresses the first half of #119. The text-box half is deliberately left — see below.

`<w:smartTag><w:r>…</w:r></w:smartTag>` is a transparent wrapper Word writes around a recognised entity — a date, a name, a place. Word 2003 wrote them freely and they still round-trip through modern Word. The `w:r` children are ordinary runs one level down, and the walk only looked at direct children of `w:p`:

```python
>>> paragraph.text
'A  B'                    # -- "TAGGED" silently gone --
>>> [r.text for r in paragraph.runs]
['A ', ' B']              # -- and the run was not in .runs either --
```

`iter_run_content()` already has a look-through mechanism for `w:fldSimple`, `w:ins` and `w:moveTo`; these are more tags for it rather than new machinery. `replace_text()` walks the same content model, so a placeholder inside a smart tag is now substituted instead of silently skipped.

The wrapper set is shared with `iter_original_run_content()` rather than listed twice. These wrappers are transparent under *both* readings of a revised document, and without that the two disagreed: `Paragraph.text` saw smart-tagged text while `.original_text` did not.

### Second commit: the block-level half

Reviewing the first commit found that adding `w:customXml` to the run-level walk alone left half the element unhandled. The schema defines four flavours — `CT_CustomXmlRun`, **`CT_CustomXmlBlock`**, `CT_CustomXmlRow` and `CT_CustomXmlCell`. The block one wraps whole paragraphs and tables, and `iter_block_content()` walked straight past it:

```python
>>> [p.text for p in document.paragraphs]
[]                        # -- the wrapped paragraph, gone entirely --
```

Worse than the run-level case: that loses a fragment of a paragraph's text, this loses the paragraphs and tables. The row and cell flavours are **not** covered — they sit inside `w:tbl`, whose row and cell access is a separate walk, and no reproducer has come up. Recorded rather than fixed blind.

### Out of scope, on purpose

`w:txbxContent` is a block-level container with its own paragraphs and tables, not a transparent wrapper, and whether its text belongs in `Paragraph.text` at all is the design question the issue records. Splicing it in silently would change `text` for content that is not in the paragraph's reading flow. #119 stays open for it.
