### PR TITLE
feat: detect ISO Strict documents and say so

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -96,6 +96,10 @@ Added
 Fixed
 ~~~~~
 
+- An ISO/IEC 29500 Strict document now raises ``StrictOoxmlNotSupportedError``, naming
+  the format and how to convert it, rather than ``AttributeError: 'lxml.etree._Element'
+  object has no attribute 'body'``. Strict is an option in Word's Save As dialogue and
+  the default in some regulated environments; reading it is still not supported.
 - Style and latent-style lookup now accepts names and style IDs containing quotes and
   other XPath metacharacters.
 - Documents with oversized attribute values, which the default ``lxml`` parser rejects,

--- a/docs/user/documents.md
+++ b/docs/user/documents.md
@@ -29,6 +29,18 @@ Things to note:
 - You can open any Word 2007 or later file this way (.doc files from Word 2003 and earlier won't work). While you might not be able to manipulate all the contents yet, whatever is already in there will load and save just fine. The feature set is still being built out, so you can't add or change things like headers or footnotes yet, but if the document has them `python-docx` is polite enough to leave them alone and smart enough to save them without actually understanding what they are.
 - If you use the same filename to open and save the file, `python-docx` will obediently overwrite the original file without a peep. You'll want to make sure that's what you intend.
 
+## Files that cannot be opened
+
+A few kinds of file look like an ordinary `.docx` and are not one. Each raises something
+that says which:
+
+| Raised | Meaning |
+| --- | --- |
+| `PackageNotFoundError` | No file at that path, or the file is not a readable OPC package — a truncated download, or not a zip archive at all. |
+| `EncryptedPackageError` | The document is password-protected. It is an OLE compound file wrapping the encrypted package, so it cannot be read without the password. Subclasses `PackageNotFoundError`. |
+| `StrictOoxmlNotSupportedError` | The document was saved as **Strict Open XML Document**, an option in Word's Save As dialogue and the default in some regulated environments. It uses the same element names in the ISO Strict namespaces rather than the Transitional ones this library reads. Re-saving from Word as "Word Document (.docx)" converts it. |
+| `ValueError` | The package is a valid OPC package but not a Word one — a `.xlsx` or `.pptx`, for instance. |
+
 ## Opening a 'file-like' document
 
 `python-docx` can open a document from a so-called *file-like* object. It can also save to a file-like object. This can be handy when you want to get the source or target document over a network connection or from a database and don't want to (or aren't allowed to) interact with the file system. In practice this means you can pass an open file or StringIO/BytesIO stream object to open or save a document like so:

--- a/src/docx/exceptions.py
+++ b/src/docx/exceptions.py
@@ -16,3 +16,17 @@ class InvalidSpanError(PythonDocxError):
 class InvalidXmlError(PythonDocxError):
     """Raised when invalid XML is encountered, such as on attempt to access a missing
     required child element."""
+
+
+class StrictOoxmlNotSupportedError(PythonDocxError):
+    """Raised on opening an ISO/IEC 29500 Strict document.
+
+    Word's "Strict Open XML Document" save format writes the same element names in the
+    Strict namespaces (``http://purl.oclc.org/ooxml/...``) rather than the Transitional
+    ones this library reads. The file is an ordinary-looking ``.docx``, so without this
+    the failure is an :class:`AttributeError` naming an lxml internal, which says
+    nothing about what is actually wrong or what to do about it.
+
+    Strict is the default in some regulated and public-sector environments. Re-saving
+    the file from Word as "Word Document (.docx)" produces the Transitional form.
+    """

--- a/src/docx/oxml/ns.py
+++ b/src/docx/oxml/ns.py
@@ -37,6 +37,25 @@ nsmap = {
 
 pfxmap = {value: key for key, value in nsmap.items()}
 
+# -- ISO/IEC 29500 **Strict** namespaces. Word's "Strict Open XML Document" save format
+# -- writes the same element names under these URIs instead of the Transitional ones in
+# -- `nsmap`. Kept deliberately *out* of `nsmap`: that mapping supplies the prefixes on
+# -- serialized output as well as the parser's lookup, so adding these would change what
+# -- gets written. This is a read-side constant, used to recognise such a document and
+# -- say so — see `StrictOoxmlNotSupportedError`. --
+STRICT_NS_PREFIX = "http://purl.oclc.org/ooxml/"
+
+STRICT_WML_MAIN = STRICT_NS_PREFIX + "wordprocessingml/main"
+
+
+def is_strict_ooxml_tag(tag: object) -> bool:
+    """True if `tag` is a Clark-notation tag name in an ISO Strict namespace.
+
+    False for anything that is not a string tag, which covers lxml's comment and
+    processing-instruction elements.
+    """
+    return isinstance(tag, str) and tag.startswith("{" + STRICT_NS_PREFIX)
+
 
 class NamespacePrefixedTag(str):
     """Value object that knows the semantics of an XML tag having a namespace prefix."""

--- a/src/docx/parts/document.py
+++ b/src/docx/parts/document.py
@@ -6,7 +6,9 @@ import os
 from typing import IO, TYPE_CHECKING, cast
 
 from docx.document import Document
+from docx.exceptions import StrictOoxmlNotSupportedError
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.oxml.ns import is_strict_ooxml_tag
 from docx.parts.altchunk import AltChunkPart
 from docx.parts.comments import CommentsPart
 from docx.parts.footnotes import FootnotesPart
@@ -91,7 +93,17 @@ class DocumentPart(StoryPart):
 
     @property
     def document(self):
-        """A |Document| object providing access to the content of this document."""
+        """A |Document| object providing access to the content of this document.
+
+        Raises |StrictOoxmlNotSupportedError| if the package is an ISO Strict document.
+        """
+        if is_strict_ooxml_tag(self._element.tag):
+            raise StrictOoxmlNotSupportedError(
+                "this document is in the ISO/IEC 29500 Strict format, which is not"
+                " supported. Its markup uses the Strict namespaces"
+                " (http://purl.oclc.org/ooxml/...) rather than the Transitional ones."
+                ' Re-save it from Word as "Word Document (.docx)" to convert it.'
+            )
         return Document(self._element, self)
 
     def drop_header_part(self, rId: str) -> None:

--- a/tests/parts/test_document.py
+++ b/tests/parts/test_document.py
@@ -6,11 +6,13 @@ import pytest
 
 from docx.comments import Comments
 from docx.enum.style import WD_STYLE_TYPE
+from docx.exceptions import StrictOoxmlNotSupportedError
 from docx.footnotes import Footnotes
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.coreprops import CoreProperties
 from docx.opc.packuri import PackURI
+from docx.oxml.parser import parse_xml
 from docx.package import Package
 from docx.parts.altchunk import AltChunkPart
 from docx.parts.comments import CommentsPart
@@ -119,6 +121,31 @@ class DescribeDocumentPart:
 
         related_parts_.__getitem__.assert_called_once_with("rId11")
         assert header_part is header_part_
+
+    def it_raises_a_meaningful_error_on_an_iso_strict_document(self, package_: Mock):
+        """Strict uses the same element names in different namespaces.
+
+        Without this the parser's class lookup never matches, `w:document` comes back a
+        plain lxml element, and the first attribute access fails with an AttributeError
+        naming nothing the user did wrong.
+        """
+        strict_document = parse_xml(
+            '<w:document xmlns:w="http://purl.oclc.org/ooxml/wordprocessingml/main">'
+            "<w:body/></w:document>"
+        )
+        document_part = DocumentPart(
+            PackURI("/word/document.xml"), CT.WML_DOCUMENT, strict_document, package_
+        )
+
+        with pytest.raises(StrictOoxmlNotSupportedError, match="ISO/IEC 29500 Strict"):
+            document_part.document
+
+    def but_an_ordinary_transitional_document_is_unaffected(self, package_: Mock):
+        document_part = DocumentPart(
+            PackURI("/word/document.xml"), CT.WML_DOCUMENT, element("w:document"), package_
+        )
+
+        assert document_part.document is not None
 
     def it_can_save_the_package_to_a_file(self, package_: Mock):
         document_part = DocumentPart(


### PR DESCRIPTION
Addresses tier 1 of #120. Reading Strict documents is still not supported; #120 stays open for tiers 2 and 3.

Word's Save As dialogue offers "Strict Open XML Document" alongside the ordinary `.docx`. It writes the same element names in the ISO/IEC 29500 Strict namespaces (`http://purl.oclc.org/ooxml/…`) rather than the Transitional ones hard-coded in `oxml/ns.py`, so the parser's namespace lookup never matches, `w:document` comes back a plain `_Element`, and the first attribute access fails:

```
AttributeError: 'lxml.etree._Element' object has no attribute 'body'
```

That names nothing the user did wrong and gives no hint the file is Strict. It now raises `StrictOoxmlNotSupportedError`, which says what the format is and that re-saving from Word as "Word Document (.docx)" converts it.

Strict is the default in some regulated and public-sector environments, so the person holding one often has no idea their `.docx` differs from anyone else's. The issue makes the case that landing detection alone is worth doing and should not wait on read support — that is what this is.

### Note on `nsmap`

The Strict URIs are deliberately kept **out** of `nsmap`. That mapping supplies the prefixes on serialized output as well as the parser's lookup, so adding them there would change what we write. This is a read-side constant only, which is also the groundwork tier 2 will need.

### Verification

Tested against a genuinely Strict package built by rewriting the WML namespace, which is exactly the difference Word's Strict save produces. Confirmed it stays catchable as `PythonDocxError`, and that ordinary Transitional documents are unaffected. The docs gain a table of the four things that can go wrong when opening a file.
