### PR TITLE
fix: rotate the page when Section.orientation changes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,6 +46,13 @@ Breaking changes
   ``Paragraph.runs`` likewise now includes runs inside a ``w:ins``.
 - ``Paragraph.text`` also now includes the cached result of a ``w:fldSimple`` — a page
   number or cross-reference displayed by such a field was previously missing from it.
+- Assigning ``Section.orientation`` now exchanges ``page_width`` and ``page_height`` as
+  well, so the page is actually rotated. Previously it set ``w:pgSz/@w:orient`` alone,
+  leaving a section declared landscape at portrait dimensions — which Word renders as
+  portrait. **If your code applies the usual workaround**, swapping the dimensions by
+  hand right after the assignment, remove it: the two swaps now cancel and the page
+  comes out the size it started. Setting the orientation it already has does nothing,
+  and margins are not moved.
 
 Added
 ~~~~~

--- a/docs/user/migrating-from-0-9.md
+++ b/docs/user/migrating-from-0-9.md
@@ -100,6 +100,26 @@ font.shading_fill          # -- an RGBColor, the string "auto", or None --
 
 0.9.x returned `9` when no outline level was set. `None` and `9` are different things: `None` means the level is inherited from the style hierarchy, and `9` is Word's explicit "Body Text" level, which deliberately excludes the paragraph from the outline. 2.0.0 reports them distinctly, and assigning a value outside 0–9 raises `ValueError` rather than writing an invalid document.
 
+### `Section.orientation`
+
+Assigning an orientation now exchanges `page_width` and `page_height` too, so the page is actually rotated. Previously it set `w:pgSz/@w:orient` alone and left the dimensions where they were, giving a section declared landscape at portrait dimensions — which Word renders as portrait.
+
+**Remove the workaround if you have one.** Nearly everyone who hit this wrote something like:
+
+```python
+section.orientation = WD_ORIENT.LANDSCAPE
+section.page_width, section.page_height = section.page_height, section.page_width  # -- delete this --
+```
+
+The two swaps now cancel out and the page comes back the size it started, which is the same broken result as before, arrived at from the other direction. Delete the second line:
+
+```python
+section.orientation = WD_ORIENT.LANDSCAPE
+section.page_width, section.page_height    # -- (11in, 8.5in) --
+```
+
+Setting the orientation a section already has does nothing, so the assignment is safe to repeat. For a page size that is not simply the rotation of the current one, set `page_width` and `page_height` explicitly afterwards. Margins are not moved.
+
 ## Removed without replacement
 
 `Section.paragraphs`  

--- a/src/docx/oxml/section.py
+++ b/src/docx/oxml/section.py
@@ -351,8 +351,31 @@ class CT_SectPr(BaseOxmlElement):
 
     @orientation.setter
     def orientation(self, value: WD_ORIENTATION | None):
-        pgSz = self.get_or_add_pgSz()
-        pgSz.orient = value if value else WD_ORIENTATION.PORTRAIT
+        """Set the orientation, swapping the page dimensions to match.
+
+        `w:orient` and `w:w`/`w:h` are independent attributes in the schema, and setting
+        only the first leaves the section declared landscape while still 8.5 inches wide
+        and 11 tall — which Word renders as portrait. Nobody wants that combination, so
+        the dimensions move with the orientation.
+
+        Only on an actual change, so setting the same orientation twice does not swap
+        twice. `w:pgMar` is deliberately left alone.
+        """
+        new_orientation = value if value else WD_ORIENTATION.PORTRAIT
+        if new_orientation != self.orientation:
+            self._swap_page_dimensions()
+        self.get_or_add_pgSz().orient = new_orientation
+
+    def _swap_page_dimensions(self) -> None:
+        """Exchange `w:pgSz/@w:w` and `@w:h`, when there is a pair of them to exchange.
+
+        A section with no `w:pgSz`, or one naming only a single dimension, has nothing
+        to rotate and is left as it is.
+        """
+        pgSz = self.pgSz
+        if pgSz is None or pgSz.w is None or pgSz.h is None:
+            return
+        pgSz.w, pgSz.h = pgSz.h, pgSz.w
 
     @property
     def page_height(self) -> Length | None:

--- a/src/docx/section.py
+++ b/src/docx/section.py
@@ -354,6 +354,20 @@ class Section:
         """:ref:`WdOrientation` member specifying page orientation for this section.
 
         One of ``WD_ORIENT.PORTRAIT`` or ``WD_ORIENT.LANDSCAPE``.
+
+        Assigning a different orientation also exchanges :attr:`page_width` and
+        :attr:`page_height`, so the page is actually rotated::
+
+            section.page_width, section.page_height    # -- (8.5in, 11in) --
+            section.orientation = WD_ORIENT.LANDSCAPE
+            section.page_width, section.page_height    # -- (11in, 8.5in) --
+
+        Underneath, `w:orient` and the `w:w`/`w:h` page dimensions are independent
+        attributes, and setting only the first leaves a section declared landscape at
+        portrait dimensions — which Word renders as portrait. Set
+        :attr:`page_width` and :attr:`page_height` explicitly afterwards for a page
+        size that is not simply the rotation of the current one. Margins
+        (:attr:`left_margin` and friends) are not moved.
         """
         return self._sectPr.orientation
 

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -551,6 +551,93 @@ class DescribeSection:
         assert section._sectPr.xml == expected_xml
 
     @pytest.mark.parametrize(
+        ("sectPr_cxml", "value", "expected_cxml"),
+        [
+            # -- portrait letter rotated to landscape --
+            (
+                "w:sectPr/w:pgSz{w:w=12240,w:h=15840}",
+                WD_ORIENTATION.LANDSCAPE,
+                "w:sectPr/w:pgSz{w:w=15840,w:h=12240,w:orient=landscape}",
+            ),
+            # -- and back again --
+            (
+                "w:sectPr/w:pgSz{w:w=15840,w:h=12240,w:orient=landscape}",
+                WD_ORIENTATION.PORTRAIT,
+                "w:sectPr/w:pgSz{w:w=12240,w:h=15840}",
+            ),
+            # -- None means portrait, and rotates from landscape just the same --
+            (
+                "w:sectPr/w:pgSz{w:w=15840,w:h=12240,w:orient=landscape}",
+                None,
+                "w:sectPr/w:pgSz{w:w=12240,w:h=15840}",
+            ),
+            # -- setting the orientation it already has must not swap --
+            (
+                "w:sectPr/w:pgSz{w:w=15840,w:h=12240,w:orient=landscape}",
+                WD_ORIENTATION.LANDSCAPE,
+                "w:sectPr/w:pgSz{w:w=15840,w:h=12240,w:orient=landscape}",
+            ),
+            (
+                "w:sectPr/w:pgSz{w:w=12240,w:h=15840}",
+                WD_ORIENTATION.PORTRAIT,
+                "w:sectPr/w:pgSz{w:w=12240,w:h=15840}",
+            ),
+            # -- nothing to swap when the dimensions are absent or incomplete --
+            (
+                "w:sectPr/w:pgSz",
+                WD_ORIENTATION.LANDSCAPE,
+                "w:sectPr/w:pgSz{w:orient=landscape}",
+            ),
+            (
+                "w:sectPr/w:pgSz{w:w=12240}",
+                WD_ORIENTATION.LANDSCAPE,
+                "w:sectPr/w:pgSz{w:w=12240,w:orient=landscape}",
+            ),
+        ],
+    )
+    def and_changing_it_rotates_the_page_dimensions(
+        self,
+        sectPr_cxml: str,
+        value: WD_ORIENTATION | None,
+        expected_cxml: str,
+        document_part_: Mock,
+    ):
+        """A landscape-declared page at portrait dimensions is what Word renders as
+        portrait, which is the trap this closes."""
+        section = Section(cast(CT_SectPr, element(sectPr_cxml)), document_part_)
+        expected_xml = xml(expected_cxml)
+
+        section.orientation = value
+
+        assert section._sectPr.xml == expected_xml
+
+    def and_it_leaves_the_margins_alone(self, document_part_: Mock):
+        """Rotating the page does not move the margins; that is a separate decision."""
+        section = Section(
+            cast(
+                CT_SectPr,
+                element("w:sectPr/(w:pgSz{w:w=12240,w:h=15840},w:pgMar{w:left=1800,w:top=1440})"),
+            ),
+            document_part_,
+        )
+
+        section.orientation = WD_ORIENTATION.LANDSCAPE
+
+        assert section._sectPr.xml == xml(
+            "w:sectPr/(w:pgSz{w:w=15840,w:h=12240,w:orient=landscape},"
+            "w:pgMar{w:left=1800,w:top=1440})"
+        )
+
+    def and_rotating_twice_returns_to_where_it_started(self, document_part_: Mock):
+        original = "w:sectPr/w:pgSz{w:w=12240,w:h=15840}"
+        section = Section(cast(CT_SectPr, element(original)), document_part_)
+
+        section.orientation = WD_ORIENTATION.LANDSCAPE
+        section.orientation = WD_ORIENTATION.PORTRAIT
+
+        assert section._sectPr.xml == xml(original)
+
+    @pytest.mark.parametrize(
         ("sectPr_cxml", "margin_prop_name", "expected_value"),
         [
             ("w:sectPr/w:pgMar{w:left=120}", "left_margin", 76200),


### PR DESCRIPTION
Closes #122.

```python
>>> section.page_width, section.page_height
(7772400, 10058400)                   # -- 8.5in x 11in --
>>> section.orientation = WD_ORIENT.LANDSCAPE
>>> section.page_width, section.page_height
(7772400, 10058400)                   # -- unchanged --
```

The section was left declared landscape while still 8.5 inches wide and 11 tall, which Word renders as portrait. The property did exactly what it said — it set `w:pgSz/@w:orient` — and produced a document that did not match what the caller asked for. It is the most-reported usability trap in the upstream tracker, filed at least three times, because the fix is to swap the dimensions by hand and that is not discoverable from the API.

This is **option 1** of the three the issue lays out: swap the dimensions in the setter.

`w:orient` and `w:w`/`w:h` are genuinely independent attributes in the schema, which is the argument for the old behaviour. It is not a strong one — nobody wants a landscape-declared portrait-sized page, so there is no working code this can break, only workarounds.

- Only swaps on an actual change, so setting the same orientation twice does not swap twice.
- A `w:pgSz` with no dimensions, or only one, has nothing to rotate and is left alone.

### ⚠️ This changes public behaviour

Existing code carrying the usual workaround now double-swaps back to a portrait-sized page:

```python
section.orientation = WD_ORIENT.LANDSCAPE
section.page_width, section.page_height = section.page_height, section.page_width  # -- must be deleted --
```

Verified, and spelled out in both `HISTORY.rst` under **Breaking changes** and the migration guide. This is why it belongs in 2.0.0 rather than a later patch release.

### Margins are not moved

Whether Word relocates the margins when a section is rotated in the UI is not something I could confirm without Word, and the issue explicitly says to confirm rather than assume. Quietly moving margins someone set on purpose is a worse failure than leaving them, so they are left, and it is recorded so it can be revisited with an answer.
